### PR TITLE
Optional libxmljs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -489,7 +489,6 @@ Queue.prototype.request = function request(method, path, query, headers, data) {
         try {
           var xml = libxml.parseXml(res.payload);
 
-
           // Find error message
           message = xml.get('/Error/Message');
           if (message) {
@@ -505,7 +504,6 @@ Queue.prototype.request = function request(method, path, query, headers, data) {
           detail = xml.get('/Error/AuthenticationErrorDetail');
           if (detail) {
             detail = detail.text();
-            console.log(detail);
           }
         } catch (e) {
           // Ignore parsing errors

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -7,9 +7,9 @@ var querystring = require('querystring');
 var crypto      = require('crypto');
 var events      = require('events');
 var util        = require('util');
-var libxml      = require('libxmljs');
 var agent       = require('./agent');
 var utils       = require('./utils');
+var xml         = require('./xml');
 
 /*
  * Azure storage service version
@@ -484,53 +484,11 @@ Queue.prototype.request = function request(method, path, query, headers, data) {
           return res;
         }
 
-        // Parse payload for error message and code
-        var message, code, detail;
-        try {
-          var xml = libxml.parseXml(res.payload);
-
-          // Find error message
-          message = xml.get('/Error/Message');
-          if (message) {
-            message = message.text();
-          }
-
-          // Find error code
-          code = xml.get('/Error/Code');
-          if (code) {
-            code = code.text();
-          }
-
-          detail = xml.get('/Error/AuthenticationErrorDetail');
-          if (detail) {
-            detail = detail.text();
-          }
-        } catch (e) {
-          // Ignore parsing errors
-        }
-
-        // Find default message and code
-        if (!message) {
-          message = "No error message given, in payload '" + res.payload + "'";
-        }
-        if (!code) {
-          if (500 <= res.statusCode && res.statusCode < 600) {
-            code = 'InternalErrorWithoutCode';
-          } else {
-            code = 'ErrorWithoutCode';
-          }
-        }
-
-        // Construct error object
-        var err         = new Error(message);
-        err.name        = code + 'Error';
-        err.code        = code;
-        err.statusCode  = res.statusCode;
-        err.detail      = detail;
-        err.payload     = res.payload;
-
+        // Parse error code
+        var err = xml.queueParseError(res);
+        err.retries = retry;
         debug("Error code: %s for %s %s on retry: %s",
-              code, method, path, retry);
+              err.code, method, path, retry);
 
         // Throw the constructed error
         throw err;
@@ -581,50 +539,7 @@ Queue.prototype.listQueues = function listQueues(options) {
   if (options.metadata)   query.include     = 'metadata';
 
   // Send request with retry policy
-  return this.request('GET', '/', query, {}).then(function(res) {
-    // Get results
-    var xml     = libxml.parseXml(res.payload);
-    var queues  = xml.get('/EnumerationResults/Queues').childNodes();
-
-    // Construct results
-    var result = {
-      queues: queues.map(function(queue) {
-        var metadata = undefined;
-        var metaNode = queue.get('Metadata');
-        if (metaNode) {
-          metadata = {};
-          metaNode.childNodes().forEach(function(node) {
-            metadata[node.name()] = node.text();
-          });
-        }
-        return {
-          name:     queue.get('Name').text(),
-          metadata: metadata
-        };
-      })
-    };
-
-    // Get Marker, Prefix, MaxResults and NextMarker, if present
-    var marker = xml.get('/EnumerationResults/Marker');
-    if (marker) {
-      result.marker = marker.text();
-    }
-    var prefix = xml.get('/EnumerationResults/Prefix');
-    if (prefix) {
-      result.prefix = prefix.text();
-    }
-    var maxResults = xml.get('/EnumerationResults/MaxResults');
-    if (maxResults) {
-      result.maxResults = parseInt(maxResults.text());
-    }
-    var nextMarker = xml.get('/EnumerationResults/NextMarker');
-    if (nextMarker ) {
-      result.nextMarker = nextMarker.text();
-    }
-
-    // Return result
-    return result;
-  });
+  return this.request('GET', '/', query, {}).then(xml.queueParseListQueues);
 };
 
 // TODO: Implement someday when we need it:
@@ -844,20 +759,7 @@ Queue.prototype.peekMessages = function peekMessages(queue, options) {
   }
 
   // Send request with retry policy
-  return this.request('GET', path, query, {}).then(function(res) {
-    // Get results
-    var xml   = libxml.parseXml(res.payload);
-    var msgs  = xml.get('/QueueMessagesList').childNodes();
-    return msgs.map(function(msg) {
-      return {
-        messageId:        msg.get('MessageId').text(),
-        insertionTime:    new Date(msg.get('InsertionTime').text()),
-        expirationTime:   new Date(msg.get('ExpirationTime').text()),
-        dequeueCount:     parseInt(msg.get('DequeueCount').text()),
-        messageText:      msg.get('MessageText').text()
-      };
-    });
-  });
+  return this.request('GET', path, query, {}).then(xml.queueParsePeekMessages);
 };
 
 /**
@@ -908,22 +810,7 @@ Queue.prototype.getMessages = function getMessages(queue, options) {
   }
 
   // Send request with retry policy
-  return this.request('GET', path, query, {}).then(function(res) {
-    // Get results
-    var xml   = libxml.parseXml(res.payload);
-    var msgs  = xml.get('/QueueMessagesList').childNodes();
-    return msgs.map(function(msg) {
-      return {
-        messageId:        msg.get('MessageId').text(),
-        insertionTime:    new Date(msg.get('InsertionTime').text()),
-        expirationTime:   new Date(msg.get('ExpirationTime').text()),
-        dequeueCount:     parseInt(msg.get('DequeueCount').text()),
-        messageText:      msg.get('MessageText').text(),
-        popReceipt:       msg.get('PopReceipt').text(),
-        timeNextVisible:  new Date(msg.get('TimeNextVisible').text())
-      };
-    });
-  });
+  return this.request('GET', path, query, {}).then(xml.queueParseGetMessages);
 };
 
 /**

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -11,6 +11,12 @@ var libxml      = require('libxmljs');
 var agent       = require('./agent');
 var utils       = require('./utils');
 
+/*
+ * Azure storage service version
+ * @const
+ */
+var SERVICE_VERSION = '2015-04-05';
+
 /* Transient error codes (we'll retry request when encountering these codes */
 var TRANSIENT_ERROR_CODES = [
   // Error code for when we encounter a 5xx error, but the XML document doesn't
@@ -227,7 +233,7 @@ function authorizeWithSAS(method, path, query, headers) {
  * ```js
  * {
  *   // Value for the x-ms-version header fixing the API version
- *   version:              '2014-02-14',
+ *   version:              SERVICE_VERSION,
  *
  *   // Value for the x-ms-client-request-id header identifying the client
  *   clientId:             'fast-azure-storage',
@@ -277,7 +283,7 @@ function Queue(options) {
 
   // Set default options
   this.options = {
-    version:              '2014-02-14',
+    version:              SERVICE_VERSION,
     clientId:             'fast-azure-storage',
     timeout:              30 * 1000,
     clientTimeoutDelay:   500,
@@ -378,9 +384,10 @@ Queue.prototype.sas = function sas(queue, options) {
 
   // Construct query-string with required parameters
   var query = {
-    sv:   '2014-02-14',
+    sv:   SERVICE_VERSION,
     se:   utils.dateToISOWithoutMS(options.expiry),
     sp:   permissions,
+    spr:  'https',
     sig:  null
   };
 
@@ -399,8 +406,10 @@ Queue.prototype.sas = function sas(queue, options) {
     query.sp,
     query.st  || '',
     query.se,
-    '/' + this.options.accountId.toLowerCase() + '/' + queue,
+    '/queue/' + this.options.accountId.toLowerCase() + '/' + queue,
     query.si  || '',
+    '', // TODO: Support signed IP addresses
+    query.spr,
     query.sv
   ].join('\n');
 
@@ -476,9 +485,10 @@ Queue.prototype.request = function request(method, path, query, headers, data) {
         }
 
         // Parse payload for error message and code
-        var message, code;
+        var message, code, detail;
         try {
           var xml = libxml.parseXml(res.payload);
+
 
           // Find error message
           message = xml.get('/Error/Message');
@@ -490,6 +500,12 @@ Queue.prototype.request = function request(method, path, query, headers, data) {
           code = xml.get('/Error/Code');
           if (code) {
             code = code.text();
+          }
+
+          detail = xml.get('/Error/AuthenticationErrorDetail');
+          if (detail) {
+            detail = detail.text();
+            console.log(detail);
           }
         } catch (e) {
           // Ignore parsing errors
@@ -512,6 +528,7 @@ Queue.prototype.request = function request(method, path, query, headers, data) {
         err.name        = code + 'Error';
         err.code        = code;
         err.statusCode  = res.statusCode;
+        err.detail      = detail;
         err.payload     = res.payload;
 
         debug("Error code: %s for %s %s on retry: %s",

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -9,7 +9,7 @@ var events      = require('events');
 var util        = require('util');
 var agent       = require('./agent');
 var utils       = require('./utils');
-var xml         = require('./xml');
+var xml         = require('./xml-parser');
 
 /*
  * Azure storage service version
@@ -484,9 +484,18 @@ Queue.prototype.request = function request(method, path, query, headers, data) {
           return res;
         }
 
-        // Parse error code
-        var err = xml.queueParseError(res);
-        err.retries = retry;
+        // Parse error message
+        var data = xml.queueParseError(res);
+
+        // Construct error object
+        var err         = new Error(data.message);
+        err.name        = data.code + 'Error';
+        err.code        = data.code;
+        err.statusCode  = res.statusCode;
+        err.detail      = data.detail;
+        err.payload     = res.payload;
+        err.retries     = retry;
+
         debug("Error code: %s for %s %s on retry: %s",
               err.code, method, path, retry);
 

--- a/lib/xml-parser/index.js
+++ b/lib/xml-parser/index.js
@@ -1,0 +1,8 @@
+var debug = require('debug')('azure:xml-parser');
+try {
+  module.exports = require('./libxmljs-parser');
+} catch (err) {
+  debug("Failed to load libxmljs, falling back to pixl-xml, error: %s",
+        err.stack);
+  module.exports = require('./pixl-xml-parser');
+}

--- a/lib/xml-parser/libxmljs-parser.js
+++ b/lib/xml-parser/libxmljs-parser.js
@@ -1,55 +1,50 @@
 var libxml = require('libxmljs');
 
-
-/** Parse queue error and return a error object */
+/** Parse queue error, return: {message, code, detail} */
 exports.queueParseError = function queueParseError(res) {
   // Parse payload for error message and code
-  var message, code, detail;
+  var result = {
+    message: null,
+    code: null,
+    detail: undefined
+  };
   try {
     var xml = libxml.parseXml(res.payload);
 
     // Find error message
-    message = xml.get('/Error/Message');
+    var message = xml.get('/Error/Message');
     if (message) {
-      message = message.text();
+      result.message = message.text();
     }
 
     // Find error code
-    code = xml.get('/Error/Code');
+    var code = xml.get('/Error/Code');
     if (code) {
-      code = code.text();
+      result.code = code.text();
     }
 
-    detail = xml.get('/Error/AuthenticationErrorDetail');
+    var detail = xml.get('/Error/AuthenticationErrorDetail');
     if (detail) {
-      detail = detail.text();
+      result.detail = detail.text();
     }
   } catch (e) {
     // Ignore parsing errors
   }
 
   // Find default message and code
-  if (!message) {
-    message = "No error message given, in payload '" + res.payload + "'";
+  if (!result.message) {
+    result.message = "No error message given, in payload '" + res.payload + "'";
   }
-  if (!code) {
+  if (!result.code) {
     if (500 <= res.statusCode && res.statusCode < 600) {
-      code = 'InternalErrorWithoutCode';
+      result.code = 'InternalErrorWithoutCode';
     } else {
-      code = 'ErrorWithoutCode';
+      result.code = 'ErrorWithoutCode';
     }
   }
 
-  // Construct error object
-  var err         = new Error(message);
-  err.name        = code + 'Error';
-  err.code        = code;
-  err.statusCode  = res.statusCode;
-  err.detail      = detail;
-  err.payload     = res.payload;
-
-  // Return error object
-  return err;
+  // Return result
+  return result;
 };
 
 

--- a/lib/xml-parser/pixl-xml-parser.js
+++ b/lib/xml-parser/pixl-xml-parser.js
@@ -1,0 +1,114 @@
+var XML = require('pixl-xml');
+
+/** Parse queue error, return: {message, code, detail} */
+exports.queueParseError = function queueParseError(res) {
+  // Parse payload for error message and code
+  var result = {
+    message: null,
+    code: null,
+    detail: undefined
+  };
+  try {
+    var xml = XML.parse(res.payload);
+    result.message = xml.Message;
+    result.code = xml.Code;
+    result.detail = xml.AuthenticationErrorDetail;
+  } catch (e) {
+    // Ignore parsing errors
+  }
+
+  // Find default message and code
+  if (!result.message) {
+    result.message = "No error message given, in payload '" + res.payload + "'";
+  }
+  if (!result.code) {
+    if (500 <= res.statusCode && res.statusCode < 600) {
+      result.code = 'InternalErrorWithoutCode';
+    } else {
+      result.code = 'ErrorWithoutCode';
+    }
+  }
+
+  // Return result
+  return result;
+};
+
+
+/** Parse list of queues and return object for listQueues */
+exports.queueParseListQueues = function queueParseListQueues(res) {
+  // Get results
+  var xml = XML.parse(res.payload);
+
+  var queues = (xml.Queues || {}).Queue || [];
+  if (!(queues instanceof Array)) {
+    queues = [queues];
+  }
+
+  var result = {
+    queues: queues.map(function(queue) {
+      var metadata = undefined;
+      if (queue.hasOwnProperty('Metadata')) {
+        metadata = queue.Metadata || {};
+      }
+      return {
+        name: queue.Name,
+        metadata: metadata
+      };
+    })
+  };
+
+  // Get Marker, Prefix, MaxResults and NextMarker, if present
+  if (xml.hasOwnProperty('Marker')) {
+    result.marker = xml.Marker;
+  }
+  if (xml.hasOwnProperty('Prefix')) {
+    result.prefix = xml.Prefix;
+  }
+  if (xml.hasOwnProperty('MaxResults')) {
+    result.maxResults = parseInt(xml.MaxResults);
+  }
+  if (xml.hasOwnProperty('NextMarker')) {
+    result.nextMarker = xml.NextMarker;
+  }
+
+  // Return result
+  return result;
+};
+
+/** Parse list of peeked messages */
+exports.queueParsePeekMessages = function queueParsePeekMessages(res) {
+  var xml = XML.parse(res.payload);
+  var msgs = xml.QueueMessage || [];
+  if (!(msgs instanceof Array)) {
+    msgs = [msgs];
+  }
+  return msgs.map(function(msg) {
+    return {
+      messageId:        msg.MessageId,
+      insertionTime:    new Date(msg.InsertionTime),
+      expirationTime:   new Date(msg.ExpirationTime),
+      dequeueCount:     parseInt(msg.DequeueCount),
+      messageText:      msg.MessageText
+    };
+  });
+};
+
+/** Parse list of messages */
+exports.queueParseGetMessages = function queueParseGetMessages(res) {
+  var xml = XML.parse(res.payload);
+  var msgs = xml.QueueMessage || [];
+  if (!(msgs instanceof Array)) {
+    msgs = [msgs];
+  }
+  return msgs.map(function(msg) {
+    return {
+      messageId:        msg.MessageId,
+      insertionTime:    new Date(msg.InsertionTime),
+      expirationTime:   new Date(msg.ExpirationTime),
+      dequeueCount:     parseInt(msg.DequeueCount),
+      messageText:      msg.MessageText,
+      popReceipt:       msg.PopReceipt,
+      timeNextVisible:  new Date(msg.TimeNextVisible)
+    };
+  });
+};

--- a/lib/xml/index.js
+++ b/lib/xml/index.js
@@ -1,0 +1,132 @@
+var libxml = require('libxmljs');
+
+
+/** Parse queue error and return a error object */
+exports.queueParseError = function queueParseError(res) {
+  // Parse payload for error message and code
+  var message, code, detail;
+  try {
+    var xml = libxml.parseXml(res.payload);
+
+    // Find error message
+    message = xml.get('/Error/Message');
+    if (message) {
+      message = message.text();
+    }
+
+    // Find error code
+    code = xml.get('/Error/Code');
+    if (code) {
+      code = code.text();
+    }
+
+    detail = xml.get('/Error/AuthenticationErrorDetail');
+    if (detail) {
+      detail = detail.text();
+    }
+  } catch (e) {
+    // Ignore parsing errors
+  }
+
+  // Find default message and code
+  if (!message) {
+    message = "No error message given, in payload '" + res.payload + "'";
+  }
+  if (!code) {
+    if (500 <= res.statusCode && res.statusCode < 600) {
+      code = 'InternalErrorWithoutCode';
+    } else {
+      code = 'ErrorWithoutCode';
+    }
+  }
+
+  // Construct error object
+  var err         = new Error(message);
+  err.name        = code + 'Error';
+  err.code        = code;
+  err.statusCode  = res.statusCode;
+  err.detail      = detail;
+  err.payload     = res.payload;
+
+  // Return error object
+  return err;
+};
+
+
+/** Parse list of queues and return object for listQueues */
+exports.queueParseListQueues = function queueParseListQueues(res) {
+  // Get results
+  var xml     = libxml.parseXml(res.payload);
+  var queues  = xml.get('/EnumerationResults/Queues').childNodes();
+
+  // Construct results
+  var result = {
+    queues: queues.map(function(queue) {
+      var metadata = undefined;
+      var metaNode = queue.get('Metadata');
+      if (metaNode) {
+        metadata = {};
+        metaNode.childNodes().forEach(function(node) {
+          metadata[node.name()] = node.text();
+        });
+      }
+      return {
+        name:     queue.get('Name').text(),
+        metadata: metadata
+      };
+    })
+  };
+
+  // Get Marker, Prefix, MaxResults and NextMarker, if present
+  var marker = xml.get('/EnumerationResults/Marker');
+  if (marker) {
+    result.marker = marker.text();
+  }
+  var prefix = xml.get('/EnumerationResults/Prefix');
+  if (prefix) {
+    result.prefix = prefix.text();
+  }
+  var maxResults = xml.get('/EnumerationResults/MaxResults');
+  if (maxResults) {
+    result.maxResults = parseInt(maxResults.text());
+  }
+  var nextMarker = xml.get('/EnumerationResults/NextMarker');
+  if (nextMarker ) {
+    result.nextMarker = nextMarker.text();
+  }
+
+  // Return result
+  return result;
+};
+
+/** Parse list of peeked messages */
+exports.queueParsePeekMessages = function queueParsePeekMessages(res) {
+  var xml = libxml.parseXml(res.payload);
+  var msgs = xml.get('/QueueMessagesList').childNodes();
+  return msgs.map(function(msg) {
+    return {
+      messageId:        msg.get('MessageId').text(),
+      insertionTime:    new Date(msg.get('InsertionTime').text()),
+      expirationTime:   new Date(msg.get('ExpirationTime').text()),
+      dequeueCount:     parseInt(msg.get('DequeueCount').text()),
+      messageText:      msg.get('MessageText').text()
+    };
+  });
+};
+
+/** Parse list of messages */
+exports.queueParseGetMessages = function queueParseGetMessages(res) {
+  var xml = libxml.parseXml(res.payload);
+  var msgs = xml.get('/QueueMessagesList').childNodes();
+  return msgs.map(function(msg) {
+    return {
+      messageId:        msg.get('MessageId').text(),
+      insertionTime:    new Date(msg.get('InsertionTime').text()),
+      expirationTime:   new Date(msg.get('ExpirationTime').text()),
+      dequeueCount:     parseInt(msg.get('DequeueCount').text()),
+      messageText:      msg.get('MessageText').text(),
+      popReceipt:       msg.get('PopReceipt').text(),
+      timeNextVisible:  new Date(msg.get('TimeNextVisible').text())
+    };
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":         "fast-azure-storage",
-  "version":      "0.2.0",
+  "version":      "0.2.1",
   "author":       "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description":  "Fast client library for azure storage services",
   "license":      "MPL-2.0",
@@ -14,7 +14,7 @@
     "url":        "https://github.com/taskcluster/fast-azure-storage.git"
   },
   "dependencies": {
-    "libxmljs":                         "^0.14.2",
+    "libxmljs":                         "^0.15.0",
     "debug":                            "^2.1.3",
     "promise":                          "^6.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":         "fast-azure-storage",
-  "version":      "0.2.1",
+  "version":      "0.3.0",
   "author":       "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description":  "Fast client library for azure storage services",
   "license":      "MPL-2.0",
@@ -14,9 +14,12 @@
     "url":        "https://github.com/taskcluster/fast-azure-storage.git"
   },
   "dependencies": {
-    "libxmljs":                         "^0.15.0",
     "debug":                            "^2.2.0",
-    "promise":                          "^7.0.4"
+    "promise":                          "^7.0.4",
+    "pixl-xml":                         "^1.0.4"
+  },
+  "optionalDependencies": {
+    "libxmljs":                         "^0.15.0"
   },
   "devDependencies": {
     "mocha":                            "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "libxmljs":                         "^0.15.0",
-    "debug":                            "^2.1.3",
-    "promise":                          "^6.1.0"
+    "debug":                            "^2.2.0",
+    "promise":                          "^7.0.4"
   },
   "devDependencies": {
     "mocha":                            "^2.2.1",

--- a/test/queue_test.js
+++ b/test/queue_test.js
@@ -4,6 +4,25 @@ suite("Queue", function() {
   var azure   = require('../');
   var utils   = require('../lib/utils');
 
+  // Hack overwriting methods on xml-parser to call both libxmljs and xmljs
+  // based parsers so we can compare their result and assert it is the same.
+  var libxmljsParser = require('../lib/xml-parser/libxmljs-parser');
+  var pixlXmlParser = require('../lib/xml-parser/pixl-xml-parser');
+  var xml = require('../lib/xml-parser');
+  Object.keys(xml).forEach(function(method) {
+    // Store methods here as we are overwriting one of these objects!
+    var m1 = libxmljsParser[method];
+    var m2 = pixlXmlParser[method];
+    xml[method] = function(res) {
+      assert.deepEqual(
+        m1(res),
+        m2(res),
+        "Expected libxmljs and pixl-xml based parsers to return the same!"
+      );
+      return m1(res);
+    };
+  });
+
   // Create azure queue client
   var queue = new azure.Queue({
     accountId:  process.env.AZURE_STORAGE_ACCOUNT,


### PR DESCRIPTION
So many have complained about `libxmljs`... Personally, I'm happy to pay upfront for performance...

But now it's an optional dependency... it'll still be installed, but failure to install isn't critical instead we'll fallback to `pixl-xml`... I think it's almost bug-free due to how JS libraries represents XML when parsed... it can be a little hard, because it switches between `undefined`, `object` and array of objects, depending on whether there is a value, no values or multiple values in the list...

I like libxmljs for being rock solid in it's API.