### PR TITLE
Queue: add popReceipt to updateMessage() response

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -912,6 +912,8 @@ Queue.prototype.updateMessage = function updateMessage(queue, text, messageId,
       throw new Error("updateMessage: Unexpected statusCode: "
                       + res.statusCode);
     }
+    return {
+      popReceipt: res.headers['x-ms-popreceipt']
+    };
   });
 };
-

--- a/test/queue_test.js
+++ b/test/queue_test.js
@@ -211,6 +211,32 @@ suite("Queue", function() {
     });
   });
 
+  test("clear, put, get, update, delete messages", function() {
+    var savedMessage;
+    return queue.clearMessages(queueName).then(function() {
+      return queue.putMessage(queueName, 'my-message7');
+    }).then(function() {
+      return queue.getMessages(queueName, {
+        visibilityTimeout:    120
+      });
+    }).then(function(messages) {
+      assert(messages.length > 0);
+      var msg = savedMessage = messages.pop();
+      assert(msg.messageText === 'my-message7');
+      return queue.updateMessage(
+        queueName, 'my-message8',
+        msg.messageId, msg.popReceipt, {
+        visibilityTimeout: 120
+      });
+    }).then(function(updateResult) {
+      return queue.deleteMessage(
+        queueName,
+        savedMessage.messageId,
+        updateResult.popReceipt
+      );
+    });
+  });
+
   test("Shared-Access-Signature (fixed string, w. start)", function() {
     var sas = queue.sas(queueName, {
       start:    new Date(Date.now() - 15 * 60 * 1000),


### PR DESCRIPTION
Currently it is impossible to use `updateMessage` to prolong message processing (i.e., with a `visibilityTimeout` > 0), because later you have to use the new `popreceipt` to delete the message.
`updateMessage` returns a new `popreceipt` which must be used to delete the message.
See [Docs](https://msdn.microsoft.com/en-us/library/azure/dd179347.aspx):
Under "URI Parameters": "popreceipt: ...A valid pop receipt value returned from an earlier call to the Get Messages or Update Message operation.".

P.S. Thanks for an awesome lib, which is really as fast as advertised!