### PR TITLE
Upgrade libxmljs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 node_js:
 - '0.12'
 - '4'
-- '5'
+- '6'
 addons:
   apt:
     sources:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pixl-xml":                         "^1.0.4"
   },
   "optionalDependencies": {
-    "libxmljs":                         "^0.15.0"
+    "libxmljs":                         "^0.18.0"
   },
   "devDependencies": {
     "mocha":                            "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":         "fast-azure-storage",
-  "version":      "0.3.4",
+  "version":      "0.3.5",
   "author":       "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description":  "Fast client library for azure storage services",
   "license":      "MPL-2.0",


### PR DESCRIPTION
Upgrading libraries... for better node 6 support... libxmljs 0.15 won't install under node 6 