### PR TITLE
Fixes for queue storage

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -652,21 +652,25 @@ Queue.prototype.getMetadata = function getMetadata(queue) {
     }
     // Extract meta-data
     var metadata = {};
-    var rawHeaderCounter = 0;
-    for(var field in res.headers) {
-      rawHeaderCounter++;
-      if (/x-ms-meta-/.test(field)) {
-        // Metadata names must adhere to the naming rules for C# identifiers, which are case-insensitive,
-        // meaning that you can set,for example, a metadata with the following form:
-        // {
-        //    applicationName: 'fast-azure-blob-storage'
-        // }
-        // In order to return the original metadata name, the header names should be read from response.rawHeaders.
-        // That is because 'https' library returns the response headers with lowercase.
-        var key = res.rawHeaders[rawHeaderCounter * 2 - 2];
-        metadata[key.substr(10)] = res.headers[field];
+
+    /*
+       Metadata names must adhere to the naming rules for C# identifiers, which are case-insensitive,
+       meaning that you can set,for example, a metadata with the following form:
+         {
+         applicationName: 'fast-azure-blob-storage'
+         }
+       In order to return the original metadata name, the header names should be read from response.rawHeaders.
+       That is because 'https' library returns the response headers with lowercase.
+       The response.rawHeaders is a list that contains the raw header names and values. It is NOT a list of tuples.
+       So, the even-numbered offsets are key values, and the odd-numbered offsets are the associated values.
+     */
+    for(var i = 0; i < res.rawHeaders.length; i += 2) {
+      var key = res.rawHeaders[i];
+      if (/x-ms-meta-/.test(key)) {
+        metadata[key.substr(10)] = res.headers[key.toLowerCase()];
       }
     }
+
     return {
       messageCount: parseInt(res.headers['x-ms-approximate-messages-count']),
       metadata:     metadata

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -110,7 +110,9 @@ var authorizeWithSharedKey = function (method, path, query, headers) {
     var field = fields[i];
     var value = headers[field];
     if (value) {
-      stringToSign += '\n' + field + ':' + value;
+      // Convert each HTTP header to lower case and
+      // trim any white space around the colon in the header.
+      stringToSign += '\n' + field.toLowerCase() + ':' + value.trim();
     }
   }
 
@@ -650,9 +652,19 @@ Queue.prototype.getMetadata = function getMetadata(queue) {
     }
     // Extract meta-data
     var metadata = {};
+    var rawHeaderCounter = 0;
     for(var field in res.headers) {
+      rawHeaderCounter++;
       if (/x-ms-meta-/.test(field)) {
-        metadata[field.substr(10)] = res.headers[field];
+        // Metadata names must adhere to the naming rules for C# identifiers, which are case-insensitive,
+        // meaning that you can set,for example, a metadata with the following form:
+        // {
+        //    applicationName: 'fast-azure-blob-storage'
+        // }
+        // In order to return the original metadata name, the header names should be read from response.rawHeaders.
+        // That is because 'https' library returns the response headers with lowercase.
+        var key = res.rawHeaders[rawHeaderCounter * 2 - 2];
+        metadata[key.substr(10)] = res.headers[field];
       }
     }
     return {

--- a/test/queue_test.js
+++ b/test/queue_test.js
@@ -36,7 +36,7 @@ suite("Queue", function() {
   test("createQueue w. meta-data", function() {
     return queue.createQueue(queueName, {
       purpose:         'testing',
-      applicationName: 'fast-azure-storage'
+      applicationName: 'fast-azure-    storage '
     });
   });
 
@@ -87,7 +87,7 @@ suite("Queue", function() {
   test("getMetadata", function() {
     return queue.getMetadata(queueName).then(function(result) {
       assert(result.metadata.purpose === 'testing');
-      assert(result.metadata.applicationName === 'fast-azure-storage');
+      assert(result.metadata.applicationName === 'fast-azure-    storage');
     });
   });
 

--- a/test/queue_test.js
+++ b/test/queue_test.js
@@ -35,7 +35,8 @@ suite("Queue", function() {
 
   test("createQueue w. meta-data", function() {
     return queue.createQueue(queueName, {
-      purpose:    'testing'
+      purpose:         'testing',
+      applicationName: 'fast-azure-storage'
     });
   });
 
@@ -86,6 +87,7 @@ suite("Queue", function() {
   test("getMetadata", function() {
     return queue.getMetadata(queueName).then(function(result) {
       assert(result.metadata.purpose === 'testing');
+      assert(result.metadata.applicationName === 'fast-azure-storage');
     });
   });
 


### PR DESCRIPTION
1) fix for how the canonicalized headers are constructed: based on the documentation, each HTTP header name should be converted to lowercase and, any white space around the colon in the header should be trimmed.

2) fix the retrieve of the queue metadata
When trying to get the metadata for a queue with the following metadata:

{
    clientName: 'fast-azure-storage'
}

the response headers will look something like this:

Transfer-Encoding: chunked
x-ms-clientname: fast-azure-storage
Date: Fri, 16 Sep 2011 01:27:38 GMT
Server: Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0

Meaning that the result of the getMetadata will be:
{
    clientname: 'fast-azure-storage'
}

This happens because the 'https' library returns the HTTP headers with lowercase. The solution was to read the header name from response.rawHeaders.