### PR TITLE
Blob storage

### DIFF
--- a/lib/blob.js
+++ b/lib/blob.js
@@ -64,7 +64,7 @@ var authorizeWithSharedKey = function (method, path, query, headers) {
     hostname: this.hostname,
     hasCanonicalizedHeaders: true,
     queryParamsSupported: QUERY_PARAMS_SUPPORTED,
-    headersValueTosign: headersValueToSign
+    headersValueToSign: headersValueToSign
   };
 
   return utils.buildRequestOptionsForAuthSharedKey(authOptions, method, path, query, headers);
@@ -76,45 +76,7 @@ var authorizeWithSharedKey = function (method, path, query, headers) {
  * Intended to define `Blob.prototype.authorize`.
  */
 function authorizeWithRefreshSAS(method, path, query, headers) {
-  var self = this;
-  // Check if we should refresh SAS
-  if (Date.now() > this._nextSASRefresh && this._nextSASRefresh !== 0) {
-    debug("Refreshing shared-access-signature");
-    // Avoid refreshing more than once
-    this._nextSASRefresh = 0;
-    // Refresh SAS
-    this._sas = Promise.resolve(this.options.sas());
-    // Update _nextSASRefresh when the SAS has been refreshed
-    this._sas.then(function(sas) {
-      sas = querystring.parse(sas);
-      // Find next sas refresh time
-      self._nextSASRefresh = (
-        new Date(sas.se).getTime() - self.options.minSASAuthExpiry
-      );
-      debug("Refreshed shared-access-signature, will refresh in %s ms",
-        self._nextSASRefresh);
-      // Throw an error if the signature expiration comes too soon
-      if (Date.now() > self._nextSASRefresh) {
-        throw new Error("Refreshed SAS, but got a Shared-Access-Signature " +
-          "that expires less than options.minSASAuthExpiry " +
-          "from now, signature expiry: " + sas.se);
-      }
-    }).catch(function(err) {
-      // If we have an error freshing SAS that's bad and we'll emit it; for most
-      // apps it's probably best to ignore this error and just crash.
-      self.emit('error', err);
-    });
-  }
-
-  // Construct request options, whenever the `_sas` promise is resolved.
-  return this._sas.then(function(sas) {
-    var authOptions = {
-      agent: self.options.agent,
-      hostname: self.hostname,
-      sas: sas
-    };
-    return utils.buildRequestOptionsForSAS(authOptions, method, path, query, headers);
-  });
+  return utils.buildRequestOptionsForRefreshSAS(this, method, path, query, headers);
 }
 
 /**
@@ -201,6 +163,8 @@ function anonymous(method, path, query, headers) {
  * ```
  */
 function Blob(options) {
+  // Initialize EventEmitter parent class
+  events.EventEmitter.call(this);
   // Set default options
   this.options = {
     version:              SERVICE_VERSION,
@@ -255,9 +219,6 @@ function Blob(options) {
   } else {
     this.authorize = anonymous;
   }
-
-  // Initialize EventEmitter parent class
-  events.EventEmitter.call(this);
 };
 
 // Export Blob
@@ -274,34 +235,32 @@ util.inherits(Blob, events.EventEmitter);
  * @param {object} options - Options for the following form:
  *  * ```js
  * {
- *   start:               new Date(), // Time from which signature is valid (optional)
- *   expiry:              new Date(), // Expiration of signature (required). Can be omitted if it is specified in the
- *                                    // associated stored access policy
- *   resourceType:        '...',      // Specifies which resources are accessible via the SAS. (required)
- *                                    // Possible values are: 'b' or 'c'.
- *                                    // Specify 'b' if the shared resource is a 'blob'. This grants access to the content and metadata of the blob.
- *                                    // Specify 'c' if the shared resource is a 'container'. This grants access to the content and metadata of any
- *                                    // blob in the container, and to the list of blobs in the container.
- *   permissions: {                   // Set of permissions delegated (required)
- *                                    // It must be omitted if it has been specified in the associated stored access policy.
- *     read:              false,      // Read the content, properties, metadata or block list of a blob or of
- *                                    // any blob in the container if the resourceType is a container.
- *     add:               false,      // Add a block to an append blob or to any append blob if the resourceType is a container.
- *     create:            false,      // Write a new blob, snapshot a blob, or copy a blob to a new blob. These operations can be done to any blob in the container
- *                                    // if the resourceType is a container.
- *     write:             false,      // Create or write content, properties, metadata, or block list. Snapshot or lease the blob. Resize the blob (page blob only).
- *                                    // These operations can be done for every blob in the container if the resourceType is a container
- *     delete:            false,      // Delete the blob or any blob in the container if the resourceType is a container.
- *     list:              false,      // List blobs in the container.
+ *   start:               new Date(),             // Time from which signature is valid (optional)
+ *   expiry:              new Date(),             // Expiration of signature (required).
+ *   resourceType:        'blob|container',       // Specifies which resources are accessible via the SAS. (required)
+ *                                                // Possible values are: 'blob' or 'container'.
+ *                                                // Specify 'blob' if the shared resource is a 'blob'. This grants access to the content and metadata of the blob.
+ *                                                // Specify 'ccontainer' if the shared resource is a 'container'. This grants access to the content and metadata of any
+ *                                                // blob in the container, and to the list of blobs in the container.
+ *   permissions: {                               // Set of permissions delegated (required)
+ *                                                // It must be omitted if it has been specified in the associated stored access policy.
+ *     read:              false,                  // Read the content, properties, metadata or block list of a blob or of
+ *                                                // any blob in the container if the resourceType is a container.
+ *     add:               false,                  // Add a block to an append blob or to any append blob if the resourceType is a container.
+ *     create:            false,                  // Write a new blob, snapshot a blob, or copy a blob to a new blob. These operations can be done to any blob in the container
+ *                                                // if the resourceType is a container.
+ *     write:             false,                  // Create or write content, properties, metadata, or block list. Snapshot or lease the blob. Resize the blob (page blob only).
+ *                                                // These operations can be done for every blob in the container if the resourceType is a container
+ *     delete:            false,                  // Delete the blob or any blob in the container if the resourceType is a container.
+ *     list:              false,                  // List blobs in the container.
  *   },
- *   cacheControl:        '...',      // The value of the Cache-Control response header to be returned. (optional)
- *   contentDisposition:  '...',      // The value of the Content-Disposition response header to be returned. (optional)
- *   contentEncoding:     '...',      // The value of the Content-Encoding response header to be returned. (optional)
- *   contentLanguage:     '...',      // The value of the Content-Language response header to be returned. (optional)
- *   contentType:         '...',      // The value of the Content-Type response header to be returned. (optional)
- *   ipAddresses:         '...',      // An IP address or a range of IP addresses. (optional)
- *   accessPolicy:        '...'       // Reference to stored access policy (optional)
- *                                    // A GUID string
+ *   cacheControl:        '...',                  // The value of the Cache-Control response header to be returned. (optional)
+ *   contentDisposition:  '...',                  // The value of the Content-Disposition response header to be returned. (optional)
+ *   contentEncoding:     '...',                  // The value of the Content-Encoding response header to be returned. (optional)
+ *   contentLanguage:     '...',                  // The value of the Content-Language response header to be returned. (optional)
+ *   contentType:         '...',                  // The value of the Content-Type response header to be returned. (optional)
+ *   accessPolicy:        '...'                   // Reference to stored access policy (optional)
+ *                                                // A GUID string
  * }
  * ```
  * @returns {string} Shared-Access-Signature on string form.
@@ -310,9 +269,11 @@ util.inherits(Blob, events.EventEmitter);
 Blob.prototype.sas = function sas(container, blob, options){
   // verify the required options
   assert(options, "options is required");
+  assert(options.expiry instanceof Date,
+    "options.expiry must be a Date object");
   assert(options.resourceType, 'options.resourceType is required');
-  assert(options.resourceType === 'b' || options.resourceType === 'c',
-    'The possible values for options.resourceType are `b` or `c`');
+  assert(options.resourceType === 'blob' || options.resourceType === 'container',
+    'The possible values for options.resourceType are `blob` or `container`');
   assert(options.permissions || options.accessPolicy, "options.permissions or options.accessPolicy must be specified");
 
   // Check that we have credentials
@@ -324,16 +285,15 @@ Blob.prototype.sas = function sas(container, blob, options){
   // Construct query-string with required parameters
   var query = {
     sv:   SERVICE_VERSION,
-    sr:   options.resourceType,
+    se:   utils.dateToISOWithoutMS(options.expiry),
+    sr:   options.resourceType === 'blob' ? 'b' : 'c',
     spr:  'https'
   }
 
-  if (options.expiry) {
-    assert(options.expiry instanceof Date, "if specified expiry must be a Date object");
-    query.se = utils.dateToISOWithoutMS(options.expiry);
-  }
-
   if (options.permissions){
+    if (options.permissions.list && options.resourceType === 'blob') {
+      throw new Error('The permission `list` is forbidden for the blob resource type.');
+    }
     // Construct permissions string (in correct order)
     var permissions = '';
     if (options.permissions.read)    permissions += 'r';
@@ -341,7 +301,7 @@ Blob.prototype.sas = function sas(container, blob, options){
     if (options.permissions.create)  permissions += 'c';
     if (options.permissions.write)   permissions += 'w';
     if (options.permissions.delete)  permissions += 'd';
-    if (options.permissions.list && options.resourceType === 'c') permissions += 'l';
+    if (options.permissions.list && options.resourceType === 'container') permissions += 'l';
 
     query.sp = permissions;
   }
@@ -363,10 +323,6 @@ Blob.prototype.sas = function sas(container, blob, options){
     query.si = options.accessPolicy;
   }
 
-  if(options.ipAddresses){
-    query.sip = options.ipAddresses;
-  }
-
   // Construct string-to-sign
   var canonicalizedResource = '/blob/' + this.options.accountId.toLowerCase() + '/' + container;
   if (blob){
@@ -378,7 +334,7 @@ Blob.prototype.sas = function sas(container, blob, options){
     query.se || '',
     canonicalizedResource,
     query.si  || '',
-    query.sip || '',
+    '', // TODO: Support signed IP addresses
     query.spr,
     query.sv,
     query.rscc || '',
@@ -875,9 +831,11 @@ Blob.prototype.setContainerACL = function setContainerACL(name, options, leaseId
     data += '<SignedIdentifier><Id>' + policy.id + '</Id>';
     data += '<AccessPolicy>';
     if (policy.start) {
+      assert(policy.start instanceof Date, "If specified, policy.start must be a Date object");
       data += '<Start>' + utils.dateToISOWithoutMS(policy.start) + '</Start>';
     }
     if (policy.expiry) {
+      assert(policy.expiry instanceof Date, "If specified, policy.expiry must be a Date object");
       data += '<Expiry>' + utils.dateToISOWithoutMS(policy.expiry) + '</Expiry>';
     }
 
@@ -981,20 +939,14 @@ Blob.prototype.listBlobs = function listBlobs(container, options) {
     if (options.marker)     query.marker      = options.marker;
     if (options.maxResults) query.maxresults  = options.maxResults;
     if (options.include)  {
-      var includeValue = '';
-      if (options.include.snapshot) {
-        includeValue += 'snapshot%82';
-      }
-      if (options.include.metadata) {
-        includeValue += 'metadata%82';
-      }
-      if (options.include.uncommittedBlobs) {
-        includeValue += 'uncommittedBlobs%82';
-      }
-      if (options.include.copy) {
-        includeValue += 'copy%82';
-      }
-      query.include = includeValue;
+      var includeValue = [
+        options.include.snapshot || '',
+        options.include.metadata || '',
+        options.include.uncommittedBlobs || '',
+        options.include.copy
+      ].join(',');
+
+      query.include = encodeURIComponent(includeValue);
     }
     if (options.delimiter)  query.delimiter = options.delimiter;
   }
@@ -1051,11 +1003,20 @@ Blob.prototype.leaseContainer = function leaseContainer(name, options) {
     headers['x-ms-lease-id'] = options.leaseId;
   }
 
-  assert(options.leaseAction === 'acquire' || options.leaseAction === 'renew' || options.leaseAction === 'change' || options.leaseAction === 'release' || options.leaseAction === 'break',
-    'The supplied `options.leaseAction` is not valid. The possible values are: acquire, renew, change, release, break');
+  assert(
+    options.leaseAction === 'acquire'
+    || options.leaseAction === 'renew'
+    || options.leaseAction === 'change'
+    || options.leaseAction === 'release'
+    || options.leaseAction === 'break',
+    'The supplied `options.leaseAction` is not valid. The possible values are: acquire, renew, change, release, break'
+  );
   headers['x-ms-lease-action'] = options.leaseAction;
 
-  if((options.leaseAction === 'renew' || options.leaseAction === 'change' || options.leaseAction === 'release') && !options.leaseId) {
+  if((options.leaseAction === 'renew'
+    || options.leaseAction === 'change'
+    || options.leaseAction === 'release')
+    && !options.leaseId) {
     throw new Error('The `options.leaseId` must be given if the `options.leaseAction` is `renew` or `change` or `release`');
   }
 

--- a/lib/blob.js
+++ b/lib/blob.js
@@ -7,12 +7,15 @@ var Promise           = require('promise');
 var utils             = require('./utils');
 var querystring       = require('querystring');
 var xml               = require('./xml-parser');
+var util              = require('util');
+var events            = require('events');
+var agent             = require('./agent');
 
 /*
  * Azure storage service version
  * @const
  */
-var SERVICE_VERSION = '2015-12-11';
+var SERVICE_VERSION = '2016-05-31';
 
 /* Transient error codes (we'll retry request when encountering these codes */
 var TRANSIENT_ERROR_CODES = [
@@ -28,7 +31,12 @@ var TRANSIENT_ERROR_CODES = [
 var QUERY_PARAMS_SUPPORTED = [
   'comp',
   'timeout',
-  'restype'
+  'restype',
+  'prefix',
+  'marker',
+  'maxResults',
+  'include',
+  'delimiter'
 ].sort();
 
 /*
@@ -36,12 +44,7 @@ var QUERY_PARAMS_SUPPORTED = [
  * Intended to define `Blob.prototype.authorize`.
  */
 var authorizeWithSharedKey = function (method, path, query, headers) {
-  // Find account id
-  var accountId = this.options.accountId;
-
-  // Build string to sign
-  var stringToSign = (
-    method + '\n' +
+  var headersValueToSign = (
     (headers['content-encoding']     || '') + '\n' +
     (headers['content-language']     || '') + '\n' +
     (headers['content-length']       || '') + '\n' +
@@ -54,62 +57,149 @@ var authorizeWithSharedKey = function (method, path, query, headers) {
     (headers['if-unmodified-since']  || '') + '\n' +
     (headers['range']                || '')
   );
+  var authOptions = {
+    accountId: this.options.accountId,
+    accessKey: this._accessKey,
+    agent: this.options.agent,
+    hostname: this.hostname,
+    hasCanonicalizedHeaders: true,
+    queryParamsSupported: QUERY_PARAMS_SUPPORTED,
+    headersValueTosign: headersValueToSign
+  };
 
-  // Construct fields as a sorted list of 'x-ms-' prefixed headers
-  var fields = [];
-  for (var field in headers) {
-    if (/^x-ms-/.test(field)) {
-      fields.push(field);
-    }
+  return utils.buildRequestOptionsForAuthSharedKey(authOptions, method, path, query, headers);
+}
+
+/*
+ * Authorize the request with a shared-access-signature that is refreshed with
+ * a function given as `options.sas`.
+ * Intended to define `Blob.prototype.authorize`.
+ */
+function authorizeWithRefreshSAS(method, path, query, headers) {
+  var self = this;
+  // Check if we should refresh SAS
+  if (Date.now() > this._nextSASRefresh && this._nextSASRefresh !== 0) {
+    debug("Refreshing shared-access-signature");
+    // Avoid refreshing more than once
+    this._nextSASRefresh = 0;
+    // Refresh SAS
+    this._sas = Promise.resolve(this.options.sas());
+    // Update _nextSASRefresh when the SAS has been refreshed
+    this._sas.then(function(sas) {
+      sas = querystring.parse(sas);
+      // Find next sas refresh time
+      self._nextSASRefresh = (
+        new Date(sas.se).getTime() - self.options.minSASAuthExpiry
+      );
+      debug("Refreshed shared-access-signature, will refresh in %s ms",
+        self._nextSASRefresh);
+      // Throw an error if the signature expiration comes too soon
+      if (Date.now() > self._nextSASRefresh) {
+        throw new Error("Refreshed SAS, but got a Shared-Access-Signature " +
+          "that expires less than options.minSASAuthExpiry " +
+          "from now, signature expiry: " + sas.se);
+      }
+    }).catch(function(err) {
+      // If we have an error freshing SAS that's bad and we'll emit it; for most
+      // apps it's probably best to ignore this error and just crash.
+      self.emit('error', err);
+    });
   }
-  fields.sort();
 
-  // Add lines for canonicalized headers using presorted list of fields
-  var N = fields.length;
-  for(var i = 0; i < N; i++) {
-    var field = fields[i];
-    var value = headers[field];
-    if (value) {
-      // Convert each HTTP header to lower case and
-      // trim any white space around the colon in the header.
-      stringToSign += '\n' + field.toLowerCase() + ':' + value.trim();
-    }
-  }
-
-  // Added lines from canonicalized resource and query-string parameters
-  // supported by this library in lexicographical order as presorted in
-  // QUERY_PARAMS_SUPPORTED
-  stringToSign += '\n/' + accountId + path;
-  var M = QUERY_PARAMS_SUPPORTED.length;
-  for(var j = 0; j < M; j++) {
-    var param = QUERY_PARAMS_SUPPORTED[j];
-    var value = query[param];
-    if (value) {
-      stringToSign += '\n' + param + ':' + value;
-    }
-  }
-
-  // Compute signature
-  var signature = crypto
-    .createHmac('sha256', this._accessKey)
-    .update(stringToSign)
-    .digest('base64');
-
-  // Set authorization header
-  headers.authorization = 'SharedKey ' + accountId + ':' + signature;
-
-  // Encode query string
-  var qs = querystring.stringify(query);
-
-  // Construct request options
-  return Promise.resolve({
-    host:       this.hostname,
-    method:     method,
-    path:       (qs.length > 0 ? path + '?' + qs : path),
-    headers:    headers
+  // Construct request options, whenever the `_sas` promise is resolved.
+  return this._sas.then(function(sas) {
+    var authOptions = {
+      agent: self.options.agent,
+      hostname: self.hostname,
+      sas: sas
+    };
+    return utils.buildRequestOptionsForSAS(authOptions, method, path, query, headers);
   });
 }
 
+/**
+ * Authorize the request with a shared-access-signature that is given with
+ * `options.sas` as string.
+ * Intended to define `Blob.prototype.authorize`.
+ */
+function authorizeWithSAS(method, path, query, headers) {
+  var authOptions = {
+    agent: this.options.agent,
+    hostname: this.hostname,
+    sas: this.options.sas
+  };
+  return utils.buildRequestOptionsForSAS(authOptions, method, path, query, headers);
+}
+
+function anonymous(method, path, query, headers) {
+  // Serialize query-string
+  var qs = querystring.stringify(query);
+  if (qs.length > 0) {
+    qs += '&';
+  }
+  return Promise.resolve({
+    host:       this.hostname,
+    method:     method,
+    path:       path + '?' + qs,
+    headers:    headers,
+    agent:      this.options.agent
+  });
+}
+
+/**
+ * Blob client class for interacting with Azure Blob Storage.
+ *
+ * @class Blob
+ * @constructor
+ * @param {object} options - options on the form:
+ *
+ * ```js
+ * {
+ *   // Value for the x-ms-version header fixing the API version
+ *   version:              SERVICE_VERSION,
+ *
+ *   // Value for the x-ms-client-request-id header identifying the client
+ *   clientId:             'fast-azure-storage',
+ *
+ *   // Server-side request timeout
+ *   timeout:              30 * 1000,
+ *
+ *   // Delay between client- and server-side timeout
+ *   clientTimeoutDelay:   500,
+ *
+ *   // Max number of request retries
+ *   retries:              5,
+ *
+ *    // HTTP Agent to use (defaults to a global azure.Agent instance)
+ *   agent:                azure.Agent.globalAgent,
+ *
+ *   // Multiplier for computation of retry delay: 2 ^ retry * delayFactor
+ *   delayFactor:          100,
+ *
+ *   // Maximum retry delay in ms (defaults to 30 seconds)
+ *   maxDelay:             30 * 1000,
+ *
+ *   // Error codes for which we should retry
+ *   transientErrorCodes:  TRANSIENT_ERROR_CODES,
+ *
+ *   // Azure storage accountId (required)
+ *   accountId:            undefined,
+ *
+ *   // Azure shared accessKey, required unless options.sas is given
+ *   accessKey:            undefined,
+ *
+ *   // Function that returns SAS string or promise for SAS string, in which
+ *   // case we will refresh SAS when a request occurs less than
+ *   // minSASAuthExpiry from signature expiry. This property may also be a
+ *   // SAS string.
+ *   sas:                  undefined,
+ *
+ *   // Minimum SAS expiry before refreshing SAS credentials, if a function for
+ *   // refreshing SAS credentials is given as options.sas
+ *   minSASAuthExpiry:     15 * 60 * 1000
+ * }
+ * ```
+ */
 function Blob(options) {
   // Set default options
   this.options = {
@@ -117,12 +207,15 @@ function Blob(options) {
     clientId:             'fast-azure-storage',
     timeout:              30 * 1000,
     clientTimeoutDelay:   500,
+    agent:                agent.globalAgent,
     retries:              5,
     delayFactor:          100,
     maxDelay:             30 * 1000,
     transientErrorCodes:  TRANSIENT_ERROR_CODES,
     accountId:            undefined,
     accessKey:            undefined,
+    sas:                  undefined,
+    minSASAuthExpiry:     15 * 60 * 1000,
   };
 
   // Overwrite default options
@@ -147,16 +240,163 @@ function Blob(options) {
   if (this.options.accessKey) {
     // If set authorize to use shared key signatures
     this.authorize = authorizeWithSharedKey;
+
     // Decode accessKey
     this._accessKey = new Buffer(this.options.accessKey, 'base64');
+  } else if (this.options.sas instanceof Function) {
+    // Set authorize to use shared-access-signatures with refresh function
+    this.authorize = authorizeWithRefreshSAS;
+    // Set state with _nextSASRefresh = -1, we'll refresh on the first request
+    this._nextSASRefresh = -1;
+    this._sas = '';
+  } else if (typeof(this.options.sas) === 'string') {
+    // Set authorize to use shared-access-signature as hardcoded
+    this.authorize = authorizeWithSAS;
   } else {
-    throw new Error("Either options.accessKey, options.sas as function or " +
-      "options.sas as string must be given!");
+    this.authorize = anonymous;
   }
+
+  // Initialize EventEmitter parent class
+  events.EventEmitter.call(this);
 };
 
 // Export Blob
 module.exports = Blob;
+
+// Subclass EventEmitter
+util.inherits(Blob, events.EventEmitter);
+
+/**
+ * Generate a SAS string on the form 'key1=va1&key2=val2&...'.
+ *
+ * @param {string}  container - Name of the container that this SAS string applies to.
+ * @param {string}  blob - Name of the blob that this SAS string applies to.
+ * @param {object} options - Options for the following form:
+ *  * ```js
+ * {
+ *   start:               new Date(), // Time from which signature is valid (optional)
+ *   expiry:              new Date(), // Expiration of signature (required). Can be omitted if it is specified in the
+ *                                    // associated stored access policy
+ *   resourceType:        '...',      // Specifies which resources are accessible via the SAS. (required)
+ *                                    // Possible values are: 'b' or 'c'.
+ *                                    // Specify 'b' if the shared resource is a 'blob'. This grants access to the content and metadata of the blob.
+ *                                    // Specify 'c' if the shared resource is a 'container'. This grants access to the content and metadata of any
+ *                                    // blob in the container, and to the list of blobs in the container.
+ *   permissions: {                   // Set of permissions delegated (required)
+ *                                    // It must be omitted if it has been specified in the associated stored access policy.
+ *     read:              false,      // Read the content, properties, metadata or block list of a blob or of
+ *                                    // any blob in the container if the resourceType is a container.
+ *     add:               false,      // Add a block to an append blob or to any append blob if the resourceType is a container.
+ *     create:            false,      // Write a new blob, snapshot a blob, or copy a blob to a new blob. These operations can be done to any blob in the container
+ *                                    // if the resourceType is a container.
+ *     write:             false,      // Create or write content, properties, metadata, or block list. Snapshot or lease the blob. Resize the blob (page blob only).
+ *                                    // These operations can be done for every blob in the container if the resourceType is a container
+ *     delete:            false,      // Delete the blob or any blob in the container if the resourceType is a container.
+ *     list:              false,      // List blobs in the container.
+ *   },
+ *   cacheControl:        '...',      // The value of the Cache-Control response header to be returned. (optional)
+ *   contentDisposition:  '...',      // The value of the Content-Disposition response header to be returned. (optional)
+ *   contentEncoding:     '...',      // The value of the Content-Encoding response header to be returned. (optional)
+ *   contentLanguage:     '...',      // The value of the Content-Language response header to be returned. (optional)
+ *   contentType:         '...',      // The value of the Content-Type response header to be returned. (optional)
+ *   ipAddresses:         '...',      // An IP address or a range of IP addresses. (optional)
+ *   accessPolicy:        '...'       // Reference to stored access policy (optional)
+ *                                    // A GUID string
+ * }
+ * ```
+ * @returns {string} Shared-Access-Signature on string form.
+ *
+ */
+Blob.prototype.sas = function sas(container, blob, options){
+  // verify the required options
+  assert(options, "options is required");
+  assert(options.resourceType, 'options.resourceType is required');
+  assert(options.resourceType === 'b' || options.resourceType === 'c',
+    'The possible values for options.resourceType are `b` or `c`');
+  assert(options.permissions || options.accessPolicy, "options.permissions or options.accessPolicy must be specified");
+
+  // Check that we have credentials
+  if (!this.options.accountId ||
+    !this.options.accessKey) {
+    throw new Error("accountId and accessKey are required for SAS creation!");
+  }
+
+  // Construct query-string with required parameters
+  var query = {
+    sv:   SERVICE_VERSION,
+    sr:   options.resourceType,
+    spr:  'https'
+  }
+
+  if (options.expiry) {
+    assert(options.expiry instanceof Date, "if specified expiry must be a Date object");
+    query.se = utils.dateToISOWithoutMS(options.expiry);
+  }
+
+  if (options.permissions){
+    // Construct permissions string (in correct order)
+    var permissions = '';
+    if (options.permissions.read)    permissions += 'r';
+    if (options.permissions.add)     permissions += 'a';
+    if (options.permissions.create)  permissions += 'c';
+    if (options.permissions.write)   permissions += 'w';
+    if (options.permissions.delete)  permissions += 'd';
+    if (options.permissions.list && options.resourceType === 'c') permissions += 'l';
+
+    query.sp = permissions;
+  }
+
+  // Add optional parameters to query-string
+  if (options.cacheControl)       query.rscc = options.cacheControl;
+  if (options.contentDisposition) query.rscd = options.contentDisposition;
+  if (options.contentEncoding)    query.rsce = options.contentEncoding;
+  if (options.contentLanguage)    query.rscl = options.contentLanguage;
+  if (options.contentType)        query.rsct = options.contentType;
+
+  if (options.start) {
+    assert(options.start instanceof Date, "if specified start must be a Date object");
+    query.st = utils.dateToISOWithoutMS(options.start);
+  }
+
+  if (options.accessPolicy) {
+    assert(/^[0-9a-fA-F]{1,64}$/i.test(options.accessPolicy), 'The `options.accessPolicy` is not valid.' );
+    query.si = options.accessPolicy;
+  }
+
+  if(options.ipAddresses){
+    query.sip = options.ipAddresses;
+  }
+
+  // Construct string-to-sign
+  var canonicalizedResource = '/blob/' + this.options.accountId.toLowerCase() + '/' + container;
+  if (blob){
+    canonicalizedResource += '/' + blob;
+  }
+  var stringToSign = [
+    query.sp || '',
+    query.st || '',
+    query.se || '',
+    canonicalizedResource,
+    query.si  || '',
+    query.sip || '',
+    query.spr,
+    query.sv,
+    query.rscc || '',
+    query.rscd || '',
+    query.rsce || '',
+    query.rscl || '',
+    query.rsct || ''
+  ].join('\n');
+
+  // Compute signature
+  query.sig = crypto
+    .createHmac('sha256', this._accessKey)
+    .update(stringToSign)
+    .digest('base64');
+
+  // Return Shared-Access-Signature as query-string
+  return querystring.stringify(query);
+};
 
 /**
  * Construct authorized request options by adding signature or
@@ -200,6 +440,11 @@ Blob.prototype.request = function request(method, path, query, headers, data) {
   headers['x-ms-version']           = this.options.version;
   headers['x-ms-client-request-id'] = this.options.clientId;
 
+  // Set content-length, if data is given
+  if (data && data.length > 0) {
+    headers['content-length'] = Buffer.byteLength(data, 'utf-8');
+  }
+
   // Construct authorized request options with shared key signature or
   // shared-access-signature.
   var self = this;
@@ -218,8 +463,7 @@ Blob.prototype.request = function request(method, path, query, headers, data) {
         }
 
         // Parse error message
-        // TODO rename the function to something generic
-        var data = xml.queueParseError(res);
+        var data = xml.parseError(res);
 
         // Construct error object
         var err         = new Error(data.message);
@@ -250,6 +494,7 @@ Blob.prototype.request = function request(method, path, query, headers, data) {
  * @returns {Promise} A promise that container has been created.
  */
 Blob.prototype.createContainer = function createContainer(name, metadata, publicLevelAccess) {
+  assert(name, 'The name of the container must be specified');
   // Construct headers
   var headers = {};
   for(var key in metadata) {
@@ -258,7 +503,10 @@ Blob.prototype.createContainer = function createContainer(name, metadata, public
     }
   }
 
-  if(publicLevelAccess && publicLevelAccess === 'container' || publicLevelAccess === 'blob') {
+  if(publicLevelAccess) {
+    assert( publicLevelAccess === 'container' || publicLevelAccess === 'blob',
+      'The `publicLevelAccess` is invalid. The possible values are: container and blob.'
+    )
     headers['x-ms-blob-public-access'] = publicLevelAccess;
   }
 
@@ -284,9 +532,11 @@ Blob.prototype.createContainer = function createContainer(name, metadata, public
  * @method setContainerMetadata
  * @param {string} name - Name of the container to set metadata on
  * @param {object} metadata - Mapping from metadata keys to values.
+ * @param {string} leaseId - Lease unique identifier. A GUID string.(optional)
  * @returns {Promise} A promise that the metadata was set.
  */
-Blob.prototype.setContainerMetadata = function setContainerMetadata(name, metadata) {
+Blob.prototype.setContainerMetadata = function setContainerMetadata(name, metadata, leaseId) {
+  assert(name, 'The name of the container must be specified');
   // Construct query string
   var query = {
     restype: 'container',
@@ -294,6 +544,11 @@ Blob.prototype.setContainerMetadata = function setContainerMetadata(name, metada
   };
   // Construct headers
   var headers = {};
+  if (leaseId) {
+    assert(utils.isValidGUID(leaseId), '`leaseId` is not a valid GUID.');
+    headers['x-ms-lease-id'] = leaseId;
+  }
+
   for(var key in metadata) {
     if (metadata.hasOwnProperty(key)) {
       headers['x-ms-meta-' + key] = metadata[key];
@@ -315,39 +570,29 @@ Blob.prototype.setContainerMetadata = function setContainerMetadata(name, metada
  * `ErrorWithoutCode`.
  *
  * @method getContainerMetadata
- * @param name - the name of the container to get metadata from.
+ * @param {string} name - the name of the container to get metadata from.
+ * @param {string} leaseId - Lease unique identifier. A GUID string.(optional)
  * @returns {Promise} a promise for metadata key/value pair
  */
-Blob.prototype.getContainerMetadata = function getContainerMetadata(name) {
+Blob.prototype.getContainerMetadata = function getContainerMetadata(name, leaseId) {
+  assert(name, 'The name of the container must be specified');
   // Construct the query string
   var query = {
     comp: 'metadata',
     restype: 'container'
   }
   var path = "/" + name;
-  return this.request('HEAD', path, query, {}).then(function(response) {
+  var headers = {};
+  if (leaseId) {
+    assert(utils.isValidGUID(leaseId), '`leaseId` is not a valid GUID.');
+    headers['x-ms-lease-id'] = leaseId;
+  }
+  return this.request('HEAD', path, query, headers).then(function(response) {
     if (response.statusCode !== 200) {
       throw new Error("getContainerMetadata: Unexpected statusCode: " + response.statusCode);
     }
     // Extract meta-data
-    var metadata = {};
-    var rawHeaderCounter = 0;
-    for(var field in response.headers) {
-      rawHeaderCounter++;
-      if (/x-ms-meta-/.test(field)) {
-        // Metadata names must adhere to the naming rules for C# identifiers, which are case-insensitive,
-        // meaning that you can set,for example, a metadata with the following form:
-        // {
-        //    applicationName: 'fast-azure-blob-storage'
-        // }
-        // In order to return the original metadata name, the header names should be read from response.rawHeaders.
-        // That is because 'https' library returns the response headers with lowercase.
-        var key = response.rawHeaders[rawHeaderCounter * 2 - 2];
-        metadata[key.substr(10)] = response.headers[field];
-      }
-    }
-
-    return metadata;
+    return utils.extractMetadataFromHeaders(response);
   });
 };
 
@@ -359,19 +604,496 @@ Blob.prototype.getContainerMetadata = function getContainerMetadata(name) {
  * Please see the documentation for more details.
  *
  * @method deleteContainer
- * @param {object} name -  Name of the container to delete
+ * @param {string} name -  Name of the container to delete
+ * @param {string} leaseId - Lease unique identifier. A GUID string.(optional)
  * @returns {Promise} A promise that container has been marked for deletion.
  */
-Blob.prototype.deleteContainer = function deleteContainer(name) {
+Blob.prototype.deleteContainer = function deleteContainer(name, leaseId) {
+  assert(name, 'The name of the container must be specified');
   // construct query string
   var query = {
     restype: 'container'
   };
   var path = '/' + name;
-  // TODO conditional headers
-  return this.request('DELETE', path, query, {}).then(function(response) {
+  var headers = {};
+  if (leaseId) {
+    assert(utils.isValidGUID(leaseId), '`leaseId` is not a valid GUID.');
+    headers['x-ms-lease-id'] = leaseId;
+  }
+  return this.request('DELETE', path, query, headers).then(function(response) {
     if(response.statusCode !== 202) {
       throw new Error('deleteContainer: Unexpected statusCode: ' + response.statusCode);
     }
+  });
+};
+
+/**
+ * List the containers under the storage account
+ *
+ * @method listContainers
+ * @param {object} options - Options on the following form:
+ *
+ * ```js
+ * {
+ *   prefix:          '...',    // Prefix of containers to list
+ *   marker:          '...',    // Marker to list containers from
+ *   maxResults:      5000,     // Max number of results
+ *   metadata:        false     // Whether or not to include metadata
+ * }
+ *
+ * * @returns {Promise} A promise for an object on the form:
+ * ```js
+ * {
+ *   containers: [
+ *     {
+ *       name:       '...',           // Name of container
+ *       properties: {
+ *          lastModified: '...',      // Container's last modified time
+ *          eTag: '...',              // The entity tag of the container
+ *          leaseStatus: '...',       // The lease status of the container
+ *          leaseState: '...',        // The lease state of the container
+ *          leaseDuration: '...'      // The lease duration of the container
+ *          publicAccessLevel: '...'  // Indicates whether data in the container may be accessed publicly and the level of access
+ *                                    // If this is not returned in the response, the container is private to the account owner.
+ *       }
+ *       metadata:   {}               // Meta-data dictionary if requested
+ *     }
+ *   ],
+ *   prefix:         '...',           // prefix given in options (if given)
+ *   marker:         '...',           // marker given in options (if given)
+ *   maxResults:     5000,            // maxResults given in options (if given)
+ *   nextMarker:     '...'            // Next marker if not at end of list
+ * }
+ * ```
+ */
+Blob.prototype.listContainers = function listContainers(options) {
+  // Ensure options
+  options = options || {};
+
+  // Construct query string
+  var query = {
+    comp: 'list'
+  };
+  if (options.prefix)     query.prefix      = options.prefix;
+  if (options.marker)     query.marker      = options.marker;
+  if (options.maxResults) query.maxresults  = options.maxResults;
+  if (options.metadata)   query.include     = 'metadata';
+
+  return this.request('GET', '/', query, {}).then(function(response) {
+    if(response.statusCode !== 200) {
+      throw new Error('listContainers: Unexpected statusCode: ' + response.statusCode);
+    }
+    return xml.blobParseListContainers(response);
+  });
+};
+
+/**
+ * Get all user-defined metadata and system properties for the container with the given name.
+ *
+ * Note, this is a `HEAD` request, so if the container is missing you get an
+ * error with `err.statusCode = 404`, but `err.code` property will be
+ * `ErrorWithoutCode`.
+ *
+ * @method getContainerProperties
+ * @param {string} name - The name of the container to get properties from.
+ * @param {string} leaseId - GUID string; lease unique identifier (optional)
+ * @returns {Promise} A promise for an object on the form:
+ * ```js
+ * {
+ *   metadata: {                 // Mapping from meta-data keys to values
+ *     '<key>':      '<value>',  // Meta-data key/value pair
+ *     ...
+ *   },
+ *   properties: {                // System properties
+ *     eTag:          '...',      // The entity tag for the container
+ *     lastModified: '...'        // The date and time the container was last modified
+ *     leaseStatus: '...',        // The lease status of the container
+ *     leaseState:  '...',        // Lease state of the container
+ *     leaseDuration: '...',      // Specifies whether the lease on a container is of infinite or fixed duration.
+ *     publicAccessLevel: '...',  // Indicates whether data in the container may be accessed publicly and the level of access
+ *                                // If this is not returned in the response, the container is private to the account owner.
+ *   }
+ * }
+ * ```
+ */
+Blob.prototype.getContainerProperties = function getContainerProperties(name, leaseId) {
+  assert(name, 'The name of the container must be specified');
+  var query = {
+    restype: 'container'
+  }
+  var path = '/' + name;
+  var headers = {};
+  if (leaseId) {
+    assert(utils.isValidGUID(leaseId), '`leaseId` is not a valid GUID.');
+    headers['x-ms-lease-id'] = leaseId;
+  }
+
+  return this.request('HEAD', path, query, headers).then(function(response) {
+    if (response.statusCode !== 200) {
+      throw new Error("getContainerProperties: Unexpected statusCode: " + response.statusCode);
+    }
+
+    // Extract metadata
+    var metadata = utils.extractMetadataFromHeaders(response);
+
+    // Extract system properties
+    var properties = {};
+    properties.eTag = response.headers.etag;
+    properties.lastModified = response.headers['last-modified'];
+    properties.leaseStatus = response.headers['x-ms-lease-status'];
+    properties.leaseState = response.headers['x-ms-lease-state'];
+    if (response.headers['x-ms-lease-duration']) {
+      properties.leaseDuration = response.headers['x-ms-lease-duration'];
+    }
+    if (response.headers['x-ms-blob-public-access']) {
+      properties.publicAccessLevel = response.headers['x-ms-blob-public-access'];
+    }
+
+    return {
+      metadata: metadata,
+      properties: properties
+    }
+  });
+};
+
+/**
+ * Gets the permissions for the container with the given name
+ *
+ * @method getContainerACL
+ * @param {string} name - Name of the container to get ACL from
+ * @param {string} leaseId - GUID string; lease unique identifier (optional)
+ * @returns {Promise} A promise for permissions
+ *  *```js
+ * {
+ *    publicAccessLevel: '...',         // Indicate whether blobs in a container may be accessed publicly.(optional)
+ *                                      // Possible values: container (full public read access for container and blob data)
+ *                                      // or blob (public read access for blobs)
+ *                                      // If it is not specified, the resource will be private and will be accessed only by the account owner
+ *    accessPolicies: [{                // The container ACL settings. An array with five maximum access policies objects (optional)
+ *      id:     '...',                  // Unique identifier, up to 64 chars in length
+ *      start:  new Date(),             // Time from which access policy is valid
+ *      expiry: new Date(),             // Expiration of access policy
+ *      permission: {                   // Set of permissions delegated
+ *        read:              false,     // Read the content, properties, metadata or block list of a blob or, of
+ *                                      // any blob in the container if the resource is a container.
+ *        add:               false,     // Add a block to an append blob or, to any append blob if the resource is a container.
+ *        create:            false,     // Write a new blob, snapshot a blob, or copy a blob to a new blob. These operations can be done to any blob in the container
+ *                                      // if the resource is a container.
+ *        write:             false,     // Create or write content, properties, metadata, or block list. Snapshot or lease the blob. Resize the blob (page blob only).
+ *                                      // These operations can be done for every blob in the container if the resource is a container
+ *        delete:            false,     // Delete the blob or, any blob in the container if the resource is a container.
+ *        list:              false,     // List blobs in the container.
+ *      }
+ *    }]
+ * }
+ * ```
+ */
+Blob.prototype.getContainerACL = function getContainerACL(name, leaseId){
+  assert(name, 'The name of the container must be specified');
+  var query = {
+    restype: 'container',
+    comp: 'acl'
+  }
+  var path = '/' + name;
+
+  var headers = {};
+  if (leaseId) {
+    assert(utils.isValidGUID(leaseId), '`leaseId` is not a valid GUID.');
+    headers['x-ms-lease-id'] = leaseId;
+  }
+
+  return this.request('GET', path, query, headers).then(function (response) {
+    if (response.statusCode !== 200) {
+      throw new Error("getContainerACL: Unexpected statusCode: " + response.statusCode);
+    }
+    return xml.blobParseContainerACL(response);
+  });
+};
+
+/**
+ * Sets the permissions for the container with the given name.
+ * The permissions indicate whether blobs in a container may be accessed publicly.
+ *
+ * @method setContainerACL
+ * @param {string} name - Name of the container to set ACL to
+ * @param {object} options - Options on the following form
+ *```js
+ * {
+ *    publicAccessLevel: '...',         // Indicate whether blobs in a container may be accessed publicly.(optional)
+ *                                      // Possible values: container (full public read access for container and blob data)
+ *                                      // or blob (public read access for blobs)
+ *                                      // If it is not specified, the resource will be private and will be accessed only by the account owner
+ *    accessPolicies: [{                // The container ACL settings. An array with five maximum access policies objects (optional)
+ *      id:     '...',                  // Unique identifier, up to 64 chars in length
+ *      start:  new Date(),             // Time from which access policy is valid
+ *      expiry: new Date(),             // Expiration of access policy
+ *      permission: {                   // Set of permissions delegated
+ *        read:              false,     // Read the content, properties, metadata or block list of a blob or of
+ *                                      // any blob in the container if the resourceType is a container.
+ *        add:               false,     // Add a block to an append blob or to any append blob if the resourceType is a container.
+ *        create:            false,     // Write a new blob, snapshot a blob, or copy a blob to a new blob. These operations can be done to any blob in the container
+ *                                      // if the resourceType is a container.
+ *        write:             false,     // Create or write content, properties, metadata, or block list. Snapshot or lease the blob. Resize the blob (page blob only).
+ *                                      // These operations can be done for every blob in the container if the resourceType is a container
+ *        delete:            false,     // Delete the blob or any blob in the container if the resourceType is a container.
+ *        list:              false,     // List blobs in the container.
+ *      }
+ *    }]
+ * }
+ * ```
+ * @param {string} leaseId - GUID string; lease unique identifier (optional)
+ * @returns {Promise} A promise that the permissions have been set
+ */
+Blob.prototype.setContainerACL = function setContainerACL(name, options, leaseId) {
+  assert(name, 'The name of the container must be specified');
+  var query = {
+    restype: 'container',
+    comp: 'acl'
+  };
+  var path = '/' + name;
+  var headers = {};
+  if (leaseId) {
+    assert(utils.isValidGUID(leaseId), '`leaseId` is not a valid GUID.');
+    headers['x-ms-lease-id'] = leaseId;
+  }
+
+  if (options.publicAccessLevel){
+    assert(options.publicAccessLevel === 'container' || options.publicAccessLevel === 'blob',
+      "The supplied `publicAccessLevel` is incorrect. The possible values are: container and blob")
+      headers['x-ms-blob-public-access'] = options.publicAccessLevel;
+  }
+  if (options.accessPolicies && options.accessPolicies.length > 5){
+    throw new Error("The supplied access policy is wrong. The maximum number of the access policies is 5");
+  }
+
+  // Construct the payload
+  var data = '<?xml version="1.0" encoding="utf-8"?>';
+  data += '<SignedIdentifiers>';
+  options.accessPolicies.forEach(function(policy){
+    assert(/^[0-9a-fA-F]{1,64}$/i.test(policy.id), 'The access policy id is not valid.' );
+
+    data += '<SignedIdentifier><Id>' + policy.id + '</Id>';
+    data += '<AccessPolicy>';
+    if (policy.start) {
+      data += '<Start>' + utils.dateToISOWithoutMS(policy.start) + '</Start>';
+    }
+    if (policy.expiry) {
+      data += '<Expiry>' + utils.dateToISOWithoutMS(policy.expiry) + '</Expiry>';
+    }
+
+    if (policy.permission) {
+      var permissions = '';
+      if (policy.permission.read)    permissions += 'r';
+      if (policy.permission.add)     permissions += 'a';
+      if (policy.permission.create)  permissions += 'c';
+      if (policy.permission.write)   permissions += 'w';
+      if (policy.permission.delete)  permissions += 'd';
+      if (policy.permission.list)    permissions += 'l';
+
+      data += '<Permission>' + permissions + '</Permission>';
+    }
+
+    data += '</AccessPolicy></SignedIdentifier>';
+  });
+  data += '</SignedIdentifiers>';
+
+  return this.request('PUT', path, query, headers, data).then(function(response){
+    if(response.statusCode !== 200){
+      throw new Error("setContainerACL: Unexpected statusCode: " + response.statusCode);
+    }
+  });
+};
+
+/**
+ * Get the list of blobs under the specified container.
+ *
+ * @method listBlobs
+ * @param {string} container - Name of the container(required)
+ * @param {object} options - Options on the following form
+ * ```js
+ * {
+ *    prefix: '...',              // Prefix of blobs to list (optional)
+ *    delimiter: '...',           // Delimiter, i.e. '/', for specifying folder hierarchy. (optional)
+ *    marker: '...',              // Marker to list blobs from (optional)
+ *    maxResults: 5000,           // The maximum number of blobs to return (optional)
+ *    include: {                  // Specifies one or more datasets to include in the response (optional)
+ *      snapshots: false,         // Include snapshots in listing
+ *      metadata: false,          // Include blob metadata in listing
+ *      uncommittedBlobs: false,  // Include uncommitted blobs in listing
+ *      copy: false               // Include metadata related to any current or previous Copy Blob operation
+ *    }
+ * }
+ * ```
+ * @returns {Promise} A promise for an object on the form:
+ * ```js
+ * {
+ *   blobs: [
+ *     {
+ *       name:       '...',               // Name of blob
+ *       snapshot:    '...',              // A date and time value that uniquely identifies the snapshot relative to its base blob
+ *       properties:  {
+ *          lastModified: '...',          // The date and time the blob was last modified
+ *          eTag: '...',                  // The entity tag of the blob
+ *          contentLength: '...',         // The content length of the blob
+ *          contentType: '...',           // The MIME content type of the blob
+ *          contentEncoding: '...',       // The content encoding of the blob
+ *          contentLanguage: '...',       // The content language of the blob
+ *          contentMD5: '...',            // An MD5 hash of the blob content
+ *          cacheControl: '...',          // The blob cache control
+ *          xmsBlobSequenceNumber: '...', // The page blob sequence number
+ *          blobType: '...',              // The type of the blob: BlockBlob | PageBlob | AppendBlob
+ *          leaseStatus: '...',           // The lease status of the blob
+ *          leaseState: '...',            // The lease state of the blob
+ *          leaseDuration: '...',         // The lease duration of the blob
+ *          copyId: '...',                // String identifier for the copy operation
+ *          copyStatus: '...',            // The state of the copy operation: pending | success | aborted | failed
+ *          copySource: '...',            // The name of the source blob of the copy operation
+ *          copyProgress: '...',          // The bytes copied/total bytes
+ *          copyCompletionTime: '...',    // The date and time the copy operation finished
+ *          copyStatusDescription: '...', // The status of the copy operation
+ *          serverEncrypted: false,       // true if the blob and application metadata are completely encrypted, and false otherwise
+ *          incrementalCopy: '...',       // true for the incremental copy blobs operation and snapshots
+ *       }
+ *       metadata:   {}                   // Meta-data dictionary if requested
+ *     }
+ *   ],
+ *   blobPrefixName: '...',
+ *   prefix:         '...',               // prefix given in options (if given)
+ *   marker:         '...',               // marker given in options (if given)
+ *   maxResults:     5000,                // maxResults given in options (if given)
+ *   nextMarker:     '...'                // Next marker if not at end of list
+ *   delimiter:      '...'                // Delimiter
+ * }
+ * ```
+ */
+Blob.prototype.listBlobs = function listBlobs(container, options) {
+  assert(container, 'The name of the container must be specified');
+  // Construct the query string
+  var query = {
+    restype: 'container',
+    comp: 'list'
+  };
+
+  assert(container, 'The container name must be specified');
+
+  if (options) {
+    if (options.prefix)     query.prefix      = options.prefix;
+    if (options.marker)     query.marker      = options.marker;
+    if (options.maxResults) query.maxresults  = options.maxResults;
+    if (options.include)  {
+      var includeValue = '';
+      if (options.include.snapshot) {
+        includeValue += 'snapshot%82';
+      }
+      if (options.include.metadata) {
+        includeValue += 'metadata%82';
+      }
+      if (options.include.uncommittedBlobs) {
+        includeValue += 'uncommittedBlobs%82';
+      }
+      if (options.include.copy) {
+        includeValue += 'copy%82';
+      }
+      query.include = includeValue;
+    }
+    if (options.delimiter)  query.delimiter = options.delimiter;
+  }
+
+  var path = '/' + container;
+  var headers = {};
+
+  return this.request('GET', path, query, headers).then(function(response){
+    if(response.statusCode !== 200){
+      throw new Error("setContainerACL: Unexpected statusCode: " + response.statusCode);
+    }
+    return xml.blobParseListBlobs(response);
+  });
+};
+
+/**
+ * Establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite.
+ *
+ * @method leaseContainer
+ * @param name - Name of the container
+ * @param {object} options - Options on the following form
+ * ```js
+ * {
+ *    leaseId: '...',           // GUID string; it is required in case of renew, change, or release of the lease.
+ *    leaseAction: '...',       // Lease container operation. The possible values are: acquire, renew, change, release, break (required)
+ *    leaseBreakPeriod: '...',  // For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.
+ *    leaseDuration: '...',     // Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires.
+ *                              // Required for acquire.
+ *    proposedLeaseId: '...'    // GUID string; Optional for acquire, required for change.
+ * }
+ * ```
+ * @returns {Promise} A promise for an object on the form:
+ * ```js
+ * {
+ *    leaseId: '...',   // The unique lease id.
+ *    leaseTime: '...'  // Approximate time remaining in the lease period, in seconds.
+ * }
+ * ```
+ */
+Blob.prototype.leaseContainer = function leaseContainer(name, options) {
+  assert(name, 'The name of the container must be specified');
+  var query = {
+    restype: 'container',
+    comp: 'lease'
+  };
+
+  var path = '/' + name;
+  var headers = {};
+
+  assert(options.leaseAction, "The `options.leaseAction` must be given");
+
+  if (options.leaseId) {
+    assert(utils.isValidGUID(options.leaseId), 'The supplied `leaseId` is not a valid GUID');
+    headers['x-ms-lease-id'] = options.leaseId;
+  }
+
+  assert(options.leaseAction === 'acquire' || options.leaseAction === 'renew' || options.leaseAction === 'change' || options.leaseAction === 'release' || options.leaseAction === 'break',
+    'The supplied `options.leaseAction` is not valid. The possible values are: acquire, renew, change, release, break');
+  headers['x-ms-lease-action'] = options.leaseAction;
+
+  if((options.leaseAction === 'renew' || options.leaseAction === 'change' || options.leaseAction === 'release') && !options.leaseId) {
+    throw new Error('The `options.leaseId` must be given if the `options.leaseAction` is `renew` or `change` or `release`');
+  }
+
+  if (options.leaseBreakPeriod){
+    assert(Number.isInteger(options.leaseBreakPeriod) && (options.leaseBreakPeriod >= 0 || options.leaseBreakPeriod <= 60),
+      'The `options.leaseBreakPeriod` is not valid; it should be a number between 0 and 60');
+    headers['x-ms-lease-break-period'] = this.options.leaseBreakPeriod;
+  }
+
+  if(options.leaseAction === 'acquire' && !options.leaseDuration){
+    throw new Error ('The `options.leaseDuration` must be given if the lease action is `acquire`');
+  }
+
+  if (options.leaseDuration) {
+    assert(options.leaseDuration >= 15 && (options.leaseDuration <= 60 || options.leaseDuration === -1),
+      'The `options.leaseDuration` must be a value between 15 and 60 or -1.');
+    headers['x-ms-lease-duration'] = options.leaseDuration.toString();
+  }
+
+  if (options.leaseAction === 'change' && !options.proposedLeaseId) {
+    throw new Error('The `options.proposedLeaseId` must be given if the lease action is `change`');
+  }
+  if(options.proposedLeaseId){
+    assert(utils.isValidGUID(this.options.leaseId), 'The supplied `proposedLeaseId` is not a valid GUID');
+    headers['x-ms-proposed-lease-id'] = options.proposedLeaseId;
+  }
+
+  return this.request('PUT', path, query, headers).then(function(response) {
+    if (response.statusCode !== 200 && response.statusCode !== 201 && response.statusCode !== 202) {
+      throw new Error("leaseContainer: Unexpected statusCode: " + response.statusCode);
+    }
+
+    var result = {
+      leaseId: response.headers['x-ms-lease-id']
+    };
+    if (response.headers['x-ms-lease-time']) {
+      result.leaseTime = response.headers['x-ms-lease-time'];
+    }
+    return result;
   });
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -491,7 +491,7 @@ Queue.prototype.request = function request(method, path, query, headers, data) {
         }
 
         // Parse error message
-        var data = xml.queueParseError(res);
+        var data = xml.parseError(res);
 
         // Construct error object
         var err         = new Error(data.message);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,8 @@
 
 var Promise     = require('promise');
 var https       = require('https');
+var crypto      = require('crypto');
+var querystring = require('querystring');
 
 /*
  * Return promise to sleep for a `delay` ms
@@ -222,3 +224,197 @@ var parseJSON = function parseJSON(data) {
 
 // Export parseJSON
 exports.parseJSON = parseJSON;
+
+/**
+ * Extracts the metadata from HTTP response header
+ *
+ * @param {object} response - HTTP response
+ * @returns {object} Mapping from meta-data keys to values
+ */
+var extractMetadataFromHeaders = function extractMetadataFromHeaders(response) {
+  var metadata = {};
+  var rawHeaderCounter = 0;
+  for(var field in response.headers) {
+    rawHeaderCounter++;
+    if (/x-ms-meta-/.test(field)) {
+      // Metadata names must adhere to the naming rules for C# identifiers, which are case-insensitive,
+      // meaning that you can set,for example, a metadata with the following form:
+      // {
+      //    applicationName: 'fast-azure-blob-storage'
+      // }
+      // In order to return the original metadata name, the header names should be read from response.rawHeaders.
+      // That is because 'https' library returns the response headers with lowercase.
+      var key = response.rawHeaders[rawHeaderCounter * 2 - 2];
+      metadata[key.substr(10)] = response.headers[field];
+    }
+  }
+
+  return metadata;
+}
+
+exports.extractMetadataFromHeaders = extractMetadataFromHeaders;
+
+/**
+ * Checks if the given value is a valid GUID
+ *
+ * A string that contains a GUID in one of the following formats (`d` represents a hexadecimal digit whose case is ignored):
+ *
+ * - 32 contiguous digits: dddddddddddddddddddddddddddddddd
+ * - Groups of 8, 4, 4, 4, and 12 digits with hyphens between the groups
+ *    dddddddd-dddd-dddd-dddd-dddddddddddd
+ *  -or-
+ *    {dddddddd-dddd-dddd-dddd-dddddddddddd}
+ * -or-
+ *    (dddddddd-dddd-dddd-dddd-dddddddddddd)
+ * -Groups of 8, 4, and 4 digits, and a subset of eight groups of 2 digits, with each group prefixed by "0x" or "0X", and separated by commas.
+ *    {0xdddddddd, 0xdddd, 0xdddd,{0xdd,0xdd,0xdd,0xdd,0xdd,0xdd,0xdd,0xdd}}
+ *
+ * @param {string} value - String value to be verified
+ * @returns {boolean} True if the value is a valid GUID
+ */
+var isValidGUID = function isValidGUID(value) {
+  // remove all embedded whitespaces
+  value = value.replace(/\s/g, '');
+
+  if ( /^[0-9a-fA-F]{1,32}$/i.test(value)
+    || /^[0-9a-fA-F]{1,8}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,12}$/i.test(value)
+    || /^\{[0-9a-fA-F]{1,8}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,12}\}$/i.test(value)
+    || /^\([0-9a-fA-F]{1,8}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,12}\)$/i.test(value)
+    || /^\{0x[0-9a-fA-F]{1,8},0x[0-9a-fA-F]{1,4},0x[0-9a-fA-F]{1,4},\{0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2}\}\}$/i.test(value)){
+    return true;
+  }
+  return false;
+}
+
+exports.isValidGUID = isValidGUID;
+
+/**
+ * Helper method to build the request options for Shared Key authentication.
+ *
+ * @param {object} options - Options on the form:
+ * ```js
+ * {
+ *    accountId: '...',                 // Azure storage accountId (required)
+ *    accessKey: '...',                 // Decoded Azure shared accessKey (required)
+ *    agent: '...',                     // HTTP Agent to use  (required)
+ *    hostname: '...',                  // The service hostname (required)
+ *    hasCanonicalizedHeaders: false,   // Specify if the string to sign includes the canonicalized headers (optional)
+ *    queryParamsSupported: '...'       // List of query-string parameter supported in lexicographical order, used for
+ *                                      // construction of the canonicalized resource.
+ *    headersValueToSign: '...'         // A string that includes all the headers value separated by a new line
+ *                                      // that should be included in the string to sign. (for more details,
+ *                                      // see the documentation of every service) (required)
+ * }
+ * ```
+ * @param {string} method - HTTP verb in upper case, e.g. `GET`.
+ * @param {string} path - Path on service resource for storage account.
+ * @param {object} query - Query-string parameters.
+ * @param {object} header - Mapping from header key in lowercase to value.
+ *
+ * @return {Promise} A promise for an options object compatible with `https.request`.
+ */
+var buildRequestOptionsForAuthSharedKey = function buildAuth(options, method, path, query, headers) {
+  // Find account id
+  var accountId = options.accountId;
+
+  // Build string to sign
+  var stringToSign = (
+    method + '\n' + options.headersValueTosign
+  );
+
+  // Construct fields as a sorted list of 'x-ms-' prefixed headers
+  if (options.hasCanonicalizedHeaders) {
+    var fields = [];
+    for (var field in headers) {
+      if (/^x-ms-/.test(field)) {
+        fields.push(field);
+      }
+    }
+    fields.sort();
+
+    // Add lines for canonicalized headers using presorted list of fields
+    var N = fields.length;
+    for(var i = 0; i < N; i++) {
+      var field = fields[i];
+      var value = headers[field];
+      if (value) {
+        // Convert each HTTP header to lower case and
+        // trim any white space around the colon in the header.
+        stringToSign += '\n' + field.toLowerCase() + ':' + value.trim();
+      }
+    }
+  }
+
+  // Added lines from canonicalized resource and query-string parameters
+  // supported by this library in lexicographical order as presorted in
+  // options.queryParamsSupported
+  stringToSign += '\n/' + accountId + path;
+  var M = options.queryParamsSupported.length;
+  for(var j = 0; j < M; j++) {
+    var param = options.queryParamsSupported[j];
+    var value = query[param];
+    if (value) {
+      stringToSign += '\n' + param + ':' + value;
+    }
+  }
+
+  // Compute signature
+  var signature = crypto
+    .createHmac('sha256', options.accessKey)
+    .update(stringToSign)
+    .digest('base64');
+
+  // Set authorization header
+  headers.authorization = 'SharedKey ' + accountId + ':' + signature;
+
+  // Encode query string
+  var qs = querystring.stringify(query);
+
+  // Construct request options
+  return Promise.resolve({
+    host:       options.hostname,
+    method:     method,
+    path:       (qs.length > 0 ? path + '?' + qs : path),
+    headers:    headers,
+    agent:      options.agent
+  });
+}
+
+exports.buildRequestOptionsForAuthSharedKey = buildRequestOptionsForAuthSharedKey;
+
+/**
+ * Helper method to build the request options for Shared-Access-Signature authentication.
+ *
+ * @param {object} options - Options on the form:
+ * ```js
+ * {
+ *    agent: '...',     // HTTP Agent to use  (required)
+ *    hostname: '...',  // The service hostname (required)
+ *    sas: '...'        // The Shared-Access-Signature string (required)
+ * }
+ * ```
+ * @param {string} method - HTTP verb in upper case, e.g. `GET`.
+ * @param {string} path - Path on service resource for storage account.
+ * @param {object} query - Query-string parameters.
+ * @param {object} header - Mapping from header key in lowercase to value.
+ *
+ * @return {Promise} A promise for an options object compatible with `https.request`.
+ */
+var buildRequestOptionsForSAS = function buildRequestOptionsForSAS(options, method, path, query, headers){
+  // Serialize query-string
+  var qs = querystring.stringify(query);
+  if (qs.length > 0) {
+    qs += '&';
+  }
+  qs += options.sas;
+  // Construct request optionss
+  return Promise.resolve({
+    host:       options.hostname,
+    method:     method,
+    path:       path + '?' + qs,
+    headers:    headers,
+    agent:      options.agent
+  });
+}
+
+exports.buildRequestOptionsForSAS = buildRequestOptionsForSAS;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ var Promise     = require('promise');
 var https       = require('https');
 var crypto      = require('crypto');
 var querystring = require('querystring');
+var debug       = require('debug')('azure:utils');
 
 /*
  * Return promise to sleep for a `delay` ms
@@ -276,12 +277,18 @@ var isValidGUID = function isValidGUID(value) {
   // remove all embedded whitespaces
   value = value.replace(/\s/g, '');
 
-  if ( /^[0-9a-fA-F]{1,32}$/i.test(value)
-    || /^[0-9a-fA-F]{1,8}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,12}$/i.test(value)
-    || /^\{[0-9a-fA-F]{1,8}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,12}\}$/i.test(value)
-    || /^\([0-9a-fA-F]{1,8}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,4}-[0-9a-fA-F]{1,12}\)$/i.test(value)
-    || /^\{0x[0-9a-fA-F]{1,8},0x[0-9a-fA-F]{1,4},0x[0-9a-fA-F]{1,4},\{0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2},0x[0-9a-fA-F]{1,2}\}\}$/i.test(value)){
-    return true;
+  var patterns = [
+    /^[0-9a-fA-F]{1,32}$/i,
+    /^[0-9a-fA-F]{1,8}(-[0-9a-fA-F]{1,4}){3}-[0-9a-fA-F]{1,12}$/i,
+    /^\{[0-9a-fA-F]{1,8}(-[0-9a-fA-F]{1,4}){3}-[0-9a-fA-F]{1,12}\}$/i,
+    /^\([0-9a-fA-F]{1,8}(-[0-9a-fA-F]{1,4}){3}-[0-9a-fA-F]{1,12}\)$/i,
+    /^\{0x[0-9a-fA-F]{1,8}(,0x[0-9a-fA-F]{1,4}){2},\{0x[0-9a-fA-F]{1,2}(,0x[0-9a-fA-F]{1,2}){7}\}\}$/i
+  ];
+
+  for (var x = 0 ; x < patterns.length ; x++) {
+    if (patterns[x].test(value)) {
+      return true;
+    }
   }
   return false;
 }
@@ -313,13 +320,13 @@ exports.isValidGUID = isValidGUID;
  *
  * @return {Promise} A promise for an options object compatible with `https.request`.
  */
-var buildRequestOptionsForAuthSharedKey = function buildAuth(options, method, path, query, headers) {
+var buildRequestOptionsForAuthSharedKey = function buildRequestOptionsForAuthSharedKey(options, method, path, query, headers) {
   // Find account id
   var accountId = options.accountId;
 
   // Build string to sign
   var stringToSign = (
-    method + '\n' + options.headersValueTosign
+    method + '\n' + options.headersValueToSign
   );
 
   // Construct fields as a sorted list of 'x-ms-' prefixed headers
@@ -400,7 +407,7 @@ exports.buildRequestOptionsForAuthSharedKey = buildRequestOptionsForAuthSharedKe
  *
  * @return {Promise} A promise for an options object compatible with `https.request`.
  */
-var buildRequestOptionsForSAS = function buildRequestOptionsForSAS(options, method, path, query, headers){
+var buildRequestOptionsForSAS = function buildRequestOptionsForSAS(options, method, path, query, headers) {
   // Serialize query-string
   var qs = querystring.stringify(query);
   if (qs.length > 0) {
@@ -418,3 +425,58 @@ var buildRequestOptionsForSAS = function buildRequestOptionsForSAS(options, meth
 }
 
 exports.buildRequestOptionsForSAS = buildRequestOptionsForSAS;
+
+/**
+ * Helper method to build the request options for Shared-Access-Signature authentication,
+ * where the shared-access-signature is refreshed with a function given as `options.sas`
+ *
+ * @param serviceInstance - `this` service instance
+ * @param method - HTTP verb in the upper case, e.g. `GET`
+ * @param path - Path on service resource for storage account
+ * @param query - Query-string parameters
+ * @param headers - Mapping fro header key in lowercase to value
+ *
+ * @returns {Promise} A promise for an options object compatible with `https.request`
+ */
+var buildRequestOptionsForRefreshSAS = function buildRequestOptionsForRefreshSAS(serviceInstance, method, path, query, headers) {
+  // Check if we should refresh SAS
+  if (Date.now() > serviceInstance._nextSASRefresh && serviceInstance._nextSASRefresh !== 0) {
+    debug("Refreshing shared-access-signature");
+    // Avoid refreshing more than once
+    serviceInstance._nextSASRefresh = 0;
+    // Refresh SAS
+    serviceInstance._sas = Promise.resolve(serviceInstance.options.sas());
+    // Update _nextSASRefresh when the SAS has been refreshed
+    serviceInstance._sas.then(function(sas) {
+      sas = querystring.parse(sas);
+      // Find next sas refresh time
+      serviceInstance._nextSASRefresh = (
+        new Date(sas.se).getTime() - serviceInstance.options.minSASAuthExpiry
+      );
+      debug("Refreshed shared-access-signature, will refresh in %s ms",
+        serviceInstance._nextSASRefresh);
+      // Throw an error if the signature expiration comes too soon
+      if (Date.now() > serviceInstance._nextSASRefresh) {
+        throw new Error("Refreshed SAS, but got a Shared-Access-Signature " +
+          "that expires less than options.minSASAuthExpiry " +
+          "from now, signature expiry: " + sas.se);
+      }
+    }).catch(function(err) {
+      // If we have an error freshing SAS that's bad and we'll emit it; for most
+      // apps it's probably best to ignore this error and just crash.
+      serviceInstance.emit('error', err);
+    });
+  }
+
+  // Construct request options, whenever the `_sas` promise is resolved.
+  return serviceInstance._sas.then(function(sas) {
+    var authOptions = {
+      agent: serviceInstance.options.agent,
+      hostname: serviceInstance.hostname,
+      sas: sas
+    };
+    return buildRequestOptionsForSAS(authOptions, method, path, query, headers);
+  });
+}
+
+exports.buildRequestOptionsForRefreshSAS = buildRequestOptionsForRefreshSAS;

--- a/lib/xml-parser/libxmljs-parser.js
+++ b/lib/xml-parser/libxmljs-parser.js
@@ -1,7 +1,7 @@
 var libxml = require('libxmljs');
 
 /* Parse queue error, return: {message, code, detail} */
-exports.queueParseError = function queueParseError(res) {
+exports.parseError = function parseError(res) {
   // Parse payload for error message and code
   var result = {
     message: null,
@@ -25,7 +25,8 @@ exports.queueParseError = function queueParseError(res) {
 
     var detail = xml.get('/Error/AuthenticationErrorDetail');
     if (detail) {
-      result.detail = detail.text();
+      // pixl-xml parser strips whitespaces from beginning and end of a node value
+      result.detail = detail.text().trim();
     }
   } catch (e) {
     // Ignore parsing errors
@@ -125,3 +126,260 @@ exports.queueParseGetMessages = function queueParseGetMessages(res) {
     };
   });
 };
+
+/* Parse list of containers and return object for listContainers */
+exports.blobParseListContainers = function blobParseListContainers(res) {
+  // Get results
+  var xml = libxml.parseXml(res.payload);
+  var containers  = xml.get('/EnumerationResults/Containers').childNodes();
+
+  // Construct results
+  var result = {
+    containers: containers.map(function(container) {
+      var metadata = undefined;
+      var metaNode = container.get('Metadata');
+      if (metaNode) {
+        metadata = {};
+        metaNode.childNodes().forEach(function(node) {
+          metadata[node.name()] = node.text();
+        });
+      }
+
+      var properties = undefined;
+      var propsNode = container.get('Properties');
+      if (propsNode) {
+        properties = {};
+        properties.eTag = propsNode.get('Etag').text();
+        properties.lastModified = propsNode.get('Last-Modified').text();
+        properties.leaseStatus = propsNode.get('LeaseStatus').text();
+        properties.leaseState = propsNode.get('LeaseState').text();
+        if (propsNode.get('LeaseDuration')) {
+          properties.leaseDuration = propsNode.get('LeaseDuration').text();
+        }
+        if (propsNode.get('PublicAccess')) {
+          properties.publicAccessLevel = propsNode.get('PublicAccess').text();
+        }
+      }
+
+      return {
+        name:       container.get('Name').text(),
+        properties: properties,
+        metadata:   metadata
+      };
+    })
+  };
+
+  // Get Marker, Prefix, MaxResults and NextMarker, if present
+  var marker = xml.get('/EnumerationResults/Marker');
+  if (marker) {
+    result.marker = marker.text();
+  }
+  var prefix = xml.get('/EnumerationResults/Prefix');
+  if (prefix) {
+    result.prefix = prefix.text();
+  }
+  var maxResults = xml.get('/EnumerationResults/MaxResults');
+  if (maxResults) {
+    result.maxResults = parseInt(maxResults.text());
+  }
+  var nextMarker = xml.get('/EnumerationResults/NextMarker');
+  if (nextMarker ) {
+    result.nextMarker = nextMarker.text();
+  }
+
+  // Return result
+  return result;
+};
+
+/* Parse container ACL and return object to getContainerACL */
+exports.blobParseContainerACL = function blobParseContainerACL(response) {
+  var xml = libxml.parseXml(response.payload);
+  var signedIdentifiers  = xml.get('/SignedIdentifiers').childNodes();
+
+  // Construct results
+  var result = {};
+  result.accessPolicies = signedIdentifiers.map(function(signedIdentifier) {
+      var policy = {};
+      var id = signedIdentifier.get('Id');
+      if (id) {
+        policy.id = id.text();
+      }
+      var accessPolicy = signedIdentifier.get('AccessPolicy');
+      if (accessPolicy) {
+        var start = accessPolicy.get('Start');
+        if (start) {
+          policy.start = start.text();
+        }
+        var expiry = accessPolicy.get('Expiry');
+        if (expiry) {
+          policy.expiry = expiry.text();
+        }
+
+        // Default values for permission
+        policy.permission = {
+          read: false,
+          add: false,
+          create: false,
+          write: false,
+          delete: false,
+          list: false
+        }
+        var permission = accessPolicy.get('Permission');
+        if (permission) {
+          permission = permission.text();
+          policy.permission.read = permission.indexOf('r') !== -1;
+          policy.permission.add = permission.indexOf('a') !== -1;
+          policy.permission.create = permission.indexOf('c') !== -1;
+          policy.permission.write = permission.indexOf('w') !== -1;
+          policy.permission.delete = permission.indexOf('d') !== -1;
+          policy.permission.list = permission.indexOf('l') !== -1;
+        }
+      }
+      return policy;
+    });
+  if (response.headers['x-ms-blob-public-access']) {
+    result.publicAccessLevel = response.headers['x-ms-blob-public-access'];
+  }
+  // return the result
+  return result;
+};
+
+/* Parse list of blobs and return object for listBlobs */
+exports.blobParseListBlobs = function blobParseListBlobs(response) {
+  var xml = libxml.parseXml(response.payload);
+
+  var result = {
+    blobs: []
+  };
+
+  if (xml.get('/Blobs')){
+    var blobs  = xml.get('/Blobs').childNodes();
+    result.blobs = blobs.map(function(blob){
+      var theBlob = {};
+
+      theBlob.name = blob.get('Name').text();
+      var snapshot = blob.get('Snapshot');
+      if (snapshot){
+        theBlob.snapshot = snapshot.text();
+      }
+
+      var properties = blob.get('Properties');
+      var lastModified = properties.get('Last-Modified');
+      if (lastModified){
+        theBlob.lastModified = lastModified.text();
+      }
+      var eTag = properties.get('Etag');
+      if (eTag){
+        theBlob.eTag = eTag.text();
+      }
+      var contentLength = properties.get('Content-Length');
+      if (contentLength) {
+        theBlob.contentLength = contentLength.text();
+      }
+      var contentType = properties.get('Content-Type');
+      if (contentType) {
+        theBlob.contentType = contentType.text();
+      }
+      var contentEncoding = properties.get('Content-Encoding');
+      if (contentEncoding) {
+        theBlob.contentEncoding = contentEncoding.text();
+      }
+      var contentLanguage = properties.get('Content-Language');
+      if (contentLanguage) {
+        theBlob.contentLanguage = contentLanguage.text();
+      }
+      var contentMD5 = properties.get('Content-MD5').text();
+      if (contentMD5) {
+        theBlob.contentMD5 = contentMD5.text();
+      }
+      var cacheControl = properties.get('Cache-Control');
+      if (cacheControl) {
+        theBlob.cacheControl = cacheControl.text();
+      }
+
+      var xmsBlobSequenceNumber = properties.get('x-ms-blob-sequence-number');
+      if (xmsBlobSequenceNumber) {
+        theBlob.xmsBlobSequenceNumber = xmsBlobSequenceNumber.text();
+      }
+      theBlob.blobType = properties.get('BlobType').text();
+
+      var leaseStatus = properties.get('LeaseStatus');
+      if (leaseStatus) {
+        theBlob.leaseStatus = leaseStatus.text();
+      }
+      var leaseState = properties.get('LeaseState');
+      if (leaseState) {
+        theBlob.leaseState = leaseState.text();
+      }
+      var leaseDuration = properties.get('LeaseDuration');
+      if (leaseDuration) {
+        theBlob.leaseDuration = leaseDuration.text();
+      }
+
+      var copyId = properties.get('CopyId');
+      if(copyId) {
+        theBlob.copyId = copyId.text();
+      }
+      var copyStatus = properties.get('CopyStatus');
+      if(copyStatus) {
+        theBlob.copyStatus = copyStatus.text();
+      }
+      var copySource = properties.get('CopySource');
+      if(copySource) {
+        theBlob.copySource = copySource.text();
+      }
+      var copyProgress = properties.get('CopyProgress');
+      if(copyProgress) {
+        theBlob.copyProgress = copyProgress.text();
+      }
+      var copyCompletionTime = properties.get('CopyCompletionTime');
+      if(copyCompletionTime) {
+        theBlob.copyCompletionTime = copyCompletionTime.text();
+      }
+      var copyStatusDescription = properties.get('CopyStatusDescription');
+      if(copyStatusDescription) {
+        theBlob.copyStatusDescription = copyStatusDescription.text();
+      }
+      theBlob.serverEncrypted = properties.get('ServerEncrypted').text();
+
+      var metadata = undefined;
+      var metaNode = blob.get('Metadata');
+      if (metaNode) {
+        metadata = {};
+        metaNode.childNodes().forEach(function(node) {
+          metadata[node.name()] = node.text();
+        });
+      }
+
+      if (metadata) {
+        theBlob.metadata = metadata;
+      }
+
+      return theBlob;
+    });
+  }
+
+  // Get Marker, Prefix, MaxResults and NextMarker, if present
+  var marker = xml.get('/EnumerationResults/Marker');
+  if (marker) {
+    result.marker = marker.text();
+  }
+  var prefix = xml.get('/EnumerationResults/Prefix');
+  if (prefix) {
+    result.prefix = prefix.text();
+  }
+  var maxResults = xml.get('/EnumerationResults/MaxResults');
+  if (maxResults) {
+    result.maxResults = parseInt(maxResults.text());
+  }
+  var nextMarker = xml.get('/EnumerationResults/NextMarker');
+  if (nextMarker) {
+    result.nextMarker = nextMarker.text();
+  }
+  var delimiter = xml.get('/EnumerationResults/Delimiter');
+  if (delimiter) {
+    result.nextMarker = delimiter.text();
+  }
+
+  return result;
+}

--- a/lib/xml-parser/pixl-xml-parser.js
+++ b/lib/xml-parser/pixl-xml-parser.js
@@ -1,7 +1,7 @@
 var XML = require('pixl-xml');
 
 /* Parse queue error, return: {message, code, detail} */
-exports.queueParseError = function queueParseError(res) {
+exports.parseError = function parseError(res) {
   // Parse payload for error message and code
   var result = {
     message: null,
@@ -10,6 +10,7 @@ exports.queueParseError = function queueParseError(res) {
   };
   try {
     var xml = XML.parse(res.payload);
+
     result.message = xml.Message;
     result.code = xml.Code;
     result.detail = xml.AuthenticationErrorDetail;
@@ -111,4 +112,229 @@ exports.queueParseGetMessages = function queueParseGetMessages(res) {
       timeNextVisible:  new Date(msg.TimeNextVisible)
     };
   });
+};
+
+/* Parse list of containers and return object for listContainers */
+exports.blobParseListContainers = function blobParseListContainers(res) {
+  // Get results
+  var xml = XML.parse(res.payload);
+  var containers  = (xml.Containers || {}).Container || [];
+
+  if(!(containers instanceof Array)) {
+    containers = [containers];
+  }
+
+  // Construct results
+  var result = {
+    containers: containers.map(function(container) {
+      var metadata = undefined;
+      if (container.hasOwnProperty('Metadata')) {
+        metadata = container.Metadata || {};
+      }
+      var properties = undefined;
+      if (container.hasOwnProperty('Properties')) {
+        properties = {};
+        properties.eTag = container.Properties.Etag;
+        properties.lastModified = container.Properties['Last-Modified'];
+        properties.leaseStatus = container.Properties.LeaseStatus;
+        properties.leaseState = container.Properties.LeaseState;
+        if (container.Properties.hasOwnProperty('LeaseDuration')) {
+          properties.leaseDuration = container.Properties.LeaseDuration;
+        }
+        if (container.Properties.hasOwnProperty('PublicAccess')) {
+          properties.publicAccessLevel = container.Properties.PublicAccess;
+        }
+      }
+
+      return {
+        name:       container.Name,
+        properties: properties,
+        metadata:   metadata
+      };
+    })
+  };
+
+  // Get Marker, Prefix, MaxResults and NextMarker, if present
+  if (xml.hasOwnProperty('Marker')) {
+    result.marker = xml.Marker;
+  }
+  if (xml.hasOwnProperty('Prefix')) {
+    result.prefix = xml.Prefix;
+  }
+  if (xml.hasOwnProperty('MaxResults')) {
+    result.maxResults = parseInt(xml.MaxResults);
+  }
+  if (xml.hasOwnProperty('NextMarker')) {
+    result.nextMarker = xml.NextMarker;
+  }
+
+  // Return result
+  return result;
+};
+
+/* Parse container ACL and return object to getContainerACL */
+exports.blobParseContainerACL = function blobParseContainerACL(response) {
+  var xml = XML.parse(response.payload);
+  var signedIdentifiers  = xml.SignedIdentifier || [];
+
+  if(!(signedIdentifiers instanceof Array)) {
+    signedIdentifiers = [signedIdentifiers];
+  }
+
+  // Construct results
+  var result = {
+    accessPolicies: signedIdentifiers.map(function(signedIdentifier) {
+      var policy = {};
+      policy.id = signedIdentifier.Id;
+
+      if (signedIdentifier.hasOwnProperty('AccessPolicy')){
+        var accessPolicy = signedIdentifier.AccessPolicy;
+
+        if (accessPolicy.hasOwnProperty('Start')) {
+          policy.start = accessPolicy.Start;
+        }
+        if (accessPolicy.hasOwnProperty('Expiry')) {
+          policy.expiry = accessPolicy.Expiry;
+        }
+
+        // Default values for permission
+        policy.permission = {
+          read: false,
+          add: false,
+          create: false,
+          write: false,
+          delete: false,
+          list: false
+        }
+        if (accessPolicy.hasOwnProperty('Permission')) {
+          var permission = accessPolicy.Permission;
+          policy.permission.read = permission.indexOf('r') !== -1;
+          policy.permission.add = permission.indexOf('a') !== -1;
+          policy.permission.create = permission.indexOf('c') !== -1;
+          policy.permission.write = permission.indexOf('w') !== -1;
+          policy.permission.delete = permission.indexOf('d') !== -1;
+          policy.permission.list = permission.indexOf('l') !== -1;
+        }
+      }
+      return policy;
+    })
+  };
+  if (response.headers['x-ms-blob-public-access']) {
+    result.publicAccessLevel = response.headers['x-ms-blob-public-access'];
+  }
+  return result;
+};
+
+/* Parse list of blobs and return object for listBlobs */
+exports.blobParseListBlobs = function blobParseListBlobs(response) {
+  var xml = XML.parse(response.payload);
+
+  var blobs  = (xml.Blobs || {}).Blob || [];
+
+  if(!(blobs instanceof Array)) {
+    blobs = [blobs];
+  }
+
+  var result = {};
+  result.blobs =  blobs.map(function(blob) {
+    var theBlob = {};
+
+    theBlob.name = blob.Name;
+    if (blob.hasOwnProperty('Snapshot')) {
+      theBlob.snapshot = blob.Snapshot;
+    }
+
+    var properties = blob.Properties;
+    if (properties.hasOwnProperty('Last-Modified')){
+      theBlob.lastModified = properties['Last-Modified'];
+    }
+    if (properties.hasOwnProperty('Etag')){
+      theBlob.eTag = properties.Etag;
+    }
+    if (properties.hasOwnProperty('Content-Length')){
+      theBlob.contentLength = properties['Content-Length'];
+    }
+    if (properties.hasOwnProperty('Content-Type')){
+      theBlob.contentType = properties['Content-Type'];
+    }
+    if (properties.hasOwnProperty('Content-Encoding')){
+      theBlob.contentEncoding = properties['Content-Encoding'];
+    }
+    if (properties.hasOwnProperty('Content-Language')){
+      theBlob.contentLanguage = properties['Content-Language'];
+    }
+    if (properties.hasOwnProperty('Content-MD5')){
+      theBlob.contentMD5 = properties['Content-MD5'];
+    }
+    if (properties.hasOwnProperty('Cache-Control')){
+      theBlob.contentControl = properties['Cache-Control'];
+    }
+
+    if (properties.hasOwnProperty('x-ms-blob-sequence-number')){
+      theBlob.xmsBlobSequenceNumber = properties['x-ms-blob-sequence-number'];
+    }
+    theBlob.blobType = properties.BlobType;
+
+    if (properties.hasOwnProperty('LeaseStatus')){
+      theBlob.leaseStatus = properties.LeaseStatus;
+    }
+    if (properties.hasOwnProperty('LeaseState')){
+      theBlob.leaseState = properties.LeaseState;
+    }
+    if (properties.hasOwnProperty('LeaseDuration')){
+      theBlob.leaseDuration = properties.LeaseDuration;
+    }
+
+    if (properties.hasOwnProperty('CopyId')){
+      theBlob.copyId = properties.CopyId;
+    }
+    if (properties.hasOwnProperty('CopyStatus')){
+      theBlob.copyStatus = properties.CopyStatus;
+    }
+    if (properties.hasOwnProperty('CopySource')){
+      theBlob.copySource = properties.CopySource;
+    }
+    if (properties.hasOwnProperty('CopyProgress')){
+      theBlob.copyProgress = properties.CopyProgress;
+    }
+    if (properties.hasOwnProperty('CopyCompletionTime')){
+      theBlob.copyCompletionTime = properties.CopyCompletionTime;
+    }
+    if (properties.hasOwnProperty('CopyStatusDescription')){
+      theBlob.copyStatusDescription = properties.CopyStatusDescription;
+    }
+
+    theBlob.serverEncrypted = properties.ServerEncrypted;
+
+    var metadata = undefined;
+    if (blob.hasOwnProperty('Metadata')) {
+      metadata = blob.Metadata || {};
+    }
+
+    if (metadata) {
+      theBlob.metadata = metadata;
+    }
+
+    return theBlob;
+  });
+
+  // Get Marker, Prefix, MaxResults and NextMarker, if present
+  if (xml.hasOwnProperty('Marker')) {
+    result.marker = xml.Marker;
+  }
+  if (xml.hasOwnProperty('Prefix')) {
+    result.prefix = xml.Prefix;
+  }
+  if (xml.hasOwnProperty('MaxResults')) {
+    result.maxResults = parseInt(xml.MaxResults);
+  }
+  if (xml.hasOwnProperty('NextMarker')) {
+    result.nextMarker = xml.NextMarker;
+  }
+  if (xml.hasOwnProperty('Delimiter')) {
+    result.delimiter = xml.Delimiter;
+  }
+
+  // Return result
+  return result;
 };

--- a/test/blob_test.js
+++ b/test/blob_test.js
@@ -1,6 +1,7 @@
-suite.only("Azure Blob", function() {
+suite("Azure Blob", function() {
   var azure   = require('../');
   var assert  = require('assert');
+  var utils   = require('../lib/utils');
 
   // Create azure blob client
   var blob = new azure.Blob({
@@ -8,40 +9,49 @@ suite.only("Azure Blob", function() {
     accessKey: process.env.AZURE_STORAGE_ACCESS_KEY
   });
 
+  var anonymousBlob = new azure.Blob({
+    accountId: process.env.AZURE_STORAGE_ACCOUNT,
+    accountKey: null
+  });
+
+  var containerNamePrefix = 'fast-azure-blob-container';
+
   suite("Container", function() {
     test('create container with metadata', function() {
-      var containerName = 'fast-azure-blob-container-with-metadata';
+      var containerName = containerNamePrefix + '-with-metadata';
       var metadata = {
         testKey: 'testValue'
       };
 
-      return blob.createContainer(containerName, metadata, null)
-        .then(function(){
-          return blob.deleteContainer(containerName);
-        });
+      return blob.createContainer(containerName, metadata, null);
     });
 
     test('create container without metadata', function() {
-      var containerName = 'fast-azure-blob-container';
+      var containerName = containerNamePrefix + '-without-metadata';
 
-      return blob.createContainer(containerName, {}, null)
-        .then(function(){
-          return blob.deleteContainer(containerName);
-        });
+      return blob.createContainer(containerName, {}, null);
     });
 
-    test('create container with container access', function() {
-      var containerName = 'fast-azure-blob-container-with-access';
+    test('create container with container access and check if the access level is correctly set', function() {
+      var containerName = containerNamePrefix + '-with-access';
 
-      // TODO verify the listing!!
-      return blob.createContainer(containerName, {}, null)
+      return blob.createContainer(containerName, {}, 'container')
         .then(function(){
-          return blob.deleteContainer(containerName);
+        /* If the publicAccessLevel is `container`, clients can call:
+          getContainerProperties, getContainerMetadata, listBlobs anonymously
+         */
+        return anonymousBlob.getContainerProperties(containerName).then(function(response){
+          assert(response.properties.eTag);
+          assert(response.properties.lastModified);
+          assert(response.properties.leaseStatus);
+          assert(response.properties.leaseState);
+          assert(response.properties.publicAccessLevel === 'container');
         });
+      })
     });
 
     test('set and get container metadata', function() {
-      var containerName = 'fast-azure-blob-container-set-get-metadata';
+      var containerName = containerNamePrefix + '-set-get-metadata';
 
       // create a container without metadata
       return blob.createContainer(containerName, {}, null)
@@ -58,10 +68,311 @@ suite.only("Azure Blob", function() {
         .then(function(result){
           // verify if the metadata was correctly set
           assert(result.appName === 'fast-azure-storage');
-
-          // delete the container
-          return blob.deleteContainer(containerName);
         });
+    });
+
+    test('list containers with prefix', function() {
+      return blob.listContainers({
+        prefix: containerNamePrefix
+      }).then(function(result){
+        assert(result.containers.length > 0);
+      });
+    });
+
+    test('list containers with prefix and metadata', function() {
+      return blob.listContainers({
+        prefix: containerNamePrefix,
+        metadata: true
+      }).then(function(result){
+        assert(result.containers.length > 0);
+        var myContainer = null;
+        result.containers.forEach(function(container) {
+          if (container.name ===  containerNamePrefix + '-with-metadata') {
+            myContainer = container;
+          }
+        });
+        assert(myContainer, "Expected to find the 'fast-azure-blob-container-with-metadata'");
+        assert(myContainer.metadata.testKey === 'testValue');
+      });
+    });
+
+    test('list containers with metadata', function() {
+      return blob.listContainers({
+        metadata: true
+      }).then(function(result){
+        assert(result.containers.length > 0);
+      });
+    });
+
+    test('get container properties', function(){
+      var containerName = containerNamePrefix + '-with-properties';
+      var metadata = {
+        appName: 'fast-azure-storage'
+      }
+      return blob.createContainer(containerName, metadata, null).then(function(){
+        return blob.getContainerProperties(containerName).then(function(response){
+          assert(response.metadata.appName === 'fast-azure-storage');
+          assert(response.properties.eTag);
+          assert(response.properties.lastModified);
+          assert(response.properties.leaseStatus);
+          assert(response.properties.leaseState);
+        });
+      });
+    });
+
+    test('get container (with access level, without metadata) properties', function(){
+      var containerName = containerNamePrefix + '-with-access';
+      return blob.getContainerProperties(containerName).then(function(response){
+        assert(response.properties.eTag);
+        assert(response.properties.lastModified);
+        assert(response.properties.leaseStatus);
+        assert(response.properties.leaseState);
+        assert(response.properties.publicAccessLevel === 'container');
+      });
+    });
+
+    test('set, get container ACL', function(){
+      var containerName = containerNamePrefix + '-with-acl';
+
+      return blob.createContainer(containerName, {}, null).then(function(){
+        var accessPolicies = [
+          {
+            id: 1,
+            start: new Date(Date.now() - 15 * 60 * 1000),
+            permission: {
+              read: true,
+              write: true,
+              list: true,
+            }
+          },
+          {
+            id: 2,
+            start: new Date(Date.now() - 15 * 60 * 1000),
+            permission: {
+              list: false,
+            }
+          }
+        ];
+        var options = {
+          publicAccessLevel: 'container',
+          accessPolicies: accessPolicies
+        }
+        return blob.setContainerACL(containerName, options);
+      }).then(function(){
+        return blob.getContainerACL(containerName).then(function (response) {
+          assert(response.publicAccessLevel === 'container');
+          assert(response.accessPolicies.length === 2);
+
+          assert(response.accessPolicies[0].id === '1');
+          assert(response.accessPolicies[0].permission.read === true);
+          assert(response.accessPolicies[0].permission.list === true);
+          assert(response.accessPolicies[0].permission.delete === false);
+          assert(response.accessPolicies[0].permission.add === false);
+          assert(response.accessPolicies[0].permission.create === false);
+          assert(response.accessPolicies[0].permission.write === true);
+
+          assert(response.accessPolicies[1].id === '2');
+          assert(response.accessPolicies[1].permission.read === false);
+          assert(response.accessPolicies[1].permission.list === false);
+          assert(response.accessPolicies[1].permission.delete === false);
+          assert(response.accessPolicies[1].permission.add === false);
+          assert(response.accessPolicies[1].permission.create === false);
+          assert(response.accessPolicies[1].permission.write === false);
+        });
+      });
+    });
+
+    test('Shared-Access-Signature (with access policy which has list permission)', function(){
+      var containerName = containerNamePrefix + '-with-acl';
+      var sas = blob.sas(containerName, null, {
+        expiry:   new Date(Date.now() + 30 * 60 * 1000),
+        resourceType: 'c',
+        accessPolicy: 1
+      });
+      var blobWithSas = new azure.Blob({
+        accountId:    blob.options.accountId,
+        sas:          sas
+      });
+      return blobWithSas.listBlobs(containerName, {});
+    });
+
+    test('Shared-Access-Signature (with access policy with forbid list)', function(){
+      var containerName = containerNamePrefix + '-with-acl';
+      var sas = blob.sas(containerName, null, {
+        expiry: new Date(Date.now() + 30 * 60 * 1000),
+        resourceType: 'c',
+        accessPolicy: 2
+      });
+      var blobWithSas = new azure.Blob({
+        accountId:    blob.options.accountId,
+        sas:          sas
+      });
+      return blobWithSas.listBlobs(containerName, {}).catch(function(err){
+        // Returns AuthorizationFailed (403). I think it should return AuthorizationPermissionMismatch (403)
+        // assert(err.code === 'AuthorizationPermissionMismatch');
+        assert(err.statusCode === 403);
+      });
+    });
+
+    test('Shared-Access-Signature (forbid list blobs)', function(){
+      var containerName = containerNamePrefix + '-with-metadata';
+      var sas = blob.sas(containerName, null, {
+        start:    new Date(Date.now() - 15 * 60 * 1000),
+        expiry:   new Date(Date.now() + 30 * 60 * 1000),
+        resourceType: 'c',
+        permissions: {
+          read: true,
+          add: false,
+          create: false,
+          write: false,
+          delete: false,
+          list: false
+        }
+      });
+      var blobWithSas = new azure.Blob({
+        accountId:    blob.options.accountId,
+        sas:          sas
+      });
+      return blobWithSas.listBlobs(containerName, {}).catch(function(err) {
+        // Should return AuthorizationPermissionMismatch (403)
+        assert(err.code === 'AuthorizationPermissionMismatch');
+        assert(err.statusCode === 403);
+      });
+    });
+
+    test("Shared-Access-Signature (will refresh)", function() {
+      var containerName = containerNamePrefix + '-with-metadata';
+      var refreshCount = 0;
+      var refreshSAS = function() {
+        refreshCount += 1;
+        return blob.sas(containerName, null, {
+          expiry:   new Date(Date.now() + 15 * 60 * 1000 + 100),
+          resourceType: 'c',
+          permissions: {
+            read: true,
+            add: true,
+            create: true,
+            write: true,
+            delete: true,
+            list: true
+          }
+        });
+      };
+      var blobWithSas = new azure.Blob({
+        accountId:        blob.options.accountId,
+        sas:              refreshSAS,
+        minSASAuthExpiry: 15 * 60 * 1000
+      });
+      return blobWithSas.listBlobs(containerName, {}).then(function() {
+        assert(refreshCount === 1);
+        return utils.sleep(200);
+      }).then(function() {
+        return blobWithSas.listBlobs(containerName, {});
+      }).then(function() {
+        assert(refreshCount === 2);
+      });
+    });
+
+    test("Shared-Access-Signature (won't refresh on every call)", function() {
+      var containerName = containerNamePrefix + '-with-metadata';
+      var refreshCount = 0;
+      var refreshSAS = function() {
+        refreshCount += 1;
+        return blob.sas(containerName, null, {
+          expiry: new Date(Date.now() + 20 * 60 * 1000),
+          resourceType: 'c',
+          permissions: {
+            read: true,
+            add: true,
+            create: true,
+            write: true,
+            delete: true,
+            list: true
+          }
+        });
+      };
+      var blobWithSas = new azure.Blob({
+        accountId:        blob.options.accountId,
+        sas:              refreshSAS,
+        minSASAuthExpiry: 15 * 60 * 1000
+      });
+      return blobWithSas.listBlobs(containerName, {}).then(function() {
+        assert(refreshCount === 1);
+        return utils.sleep(200);
+      }).then(function() {
+        return blobWithSas.listBlobs(containerName, {});
+      }).then(function() {
+        assert(refreshCount === 1);
+      });
+    });
+
+    test("Retries up to 5 times", function() {
+      var containerName = containerNamePrefix + '-with-metadata';
+      var request = utils.request;
+      var requestCount = 0;
+      utils.request = function() {
+        requestCount += 1;
+        return utils.sleep(100).then(function() {
+          var err = new Error('ECONNRESET');
+          err.code = 'ECONNRESET';
+          throw err;
+        });
+      };
+      return blob.listBlobs(containerName, {}).then(function() {
+        utils.request = request;
+        assert(false, "Expected an error");
+      }, function(err) {
+        utils.request = request;
+        assert(err.code === 'ECONNRESET');
+        assert(requestCount === 6, "Expected 1 request + 5 retries");
+      });
+    });
+
+    // TODO add more tests for SAS when blob rest endpoints are implemented
+
+    // TODO modify the test when the blobs can be created
+    test('list blobs within a container', function(){
+      var containerName = containerNamePrefix + '-with-blobs';
+
+      return blob.createContainer(containerName).then(function(){
+        return blob.listBlobs(containerName).then(function(response){
+          assert(response.blobs.length === 0);
+        });
+      })
+    });
+
+    test('acquire a lease for a container, forbid delete container and release the lease', function(){
+      var containerName = containerNamePrefix + '-with-lease';
+      return blob.createContainer(containerName).then(function(){
+        var leaseOptions = {
+          leaseAction: 'acquire',
+          leaseDuration: 15
+        };
+        return blob.leaseContainer(containerName,leaseOptions).then(function(response){
+          assert(response.leaseId);
+          return blob.deleteContainer(containerName).catch(function(err){
+            assert(err.statusCode === 412);
+            return blob.leaseContainer(containerName, {
+              leaseAction: 'release',
+              leaseId: response.leaseId
+            });
+          });
+        });
+      });
+    });
+  });
+
+  // Cleanup
+  suiteTeardown(function(){
+    // delete all containers
+    return blob.listContainers({
+      prefix: containerNamePrefix
+    }).then(function(result){
+      var deletePromises = result.containers.map(function(container){
+        return blob.deleteContainer(container.name);
+      });
+
+      return Promise.all(deletePromises);
     });
   });
 });

--- a/test/blob_test.js
+++ b/test/blob_test.js
@@ -1,4 +1,4 @@
-suite("Azure Blob", function() {
+suite.only("Azure Blob", function() {
   var azure   = require('../');
   var assert  = require('assert');
   var utils   = require('../lib/utils');
@@ -141,6 +141,8 @@ suite("Azure Blob", function() {
             start: new Date(Date.now() - 15 * 60 * 1000),
             permission: {
               read: true,
+              add: true,
+              create: true,
               write: true,
               list: true,
             }
@@ -167,8 +169,8 @@ suite("Azure Blob", function() {
           assert(response.accessPolicies[0].permission.read === true);
           assert(response.accessPolicies[0].permission.list === true);
           assert(response.accessPolicies[0].permission.delete === false);
-          assert(response.accessPolicies[0].permission.add === false);
-          assert(response.accessPolicies[0].permission.create === false);
+          assert(response.accessPolicies[0].permission.add === true);
+          assert(response.accessPolicies[0].permission.create === true);
           assert(response.accessPolicies[0].permission.write === true);
 
           assert(response.accessPolicies[1].id === '2');
@@ -186,7 +188,7 @@ suite("Azure Blob", function() {
       var containerName = containerNamePrefix + '-with-acl';
       var sas = blob.sas(containerName, null, {
         expiry:   new Date(Date.now() + 30 * 60 * 1000),
-        resourceType: 'c',
+        resourceType: 'container',
         accessPolicy: 1
       });
       var blobWithSas = new azure.Blob({
@@ -200,7 +202,7 @@ suite("Azure Blob", function() {
       var containerName = containerNamePrefix + '-with-acl';
       var sas = blob.sas(containerName, null, {
         expiry: new Date(Date.now() + 30 * 60 * 1000),
-        resourceType: 'c',
+        resourceType: 'container',
         accessPolicy: 2
       });
       var blobWithSas = new azure.Blob({
@@ -219,7 +221,7 @@ suite("Azure Blob", function() {
       var sas = blob.sas(containerName, null, {
         start:    new Date(Date.now() - 15 * 60 * 1000),
         expiry:   new Date(Date.now() + 30 * 60 * 1000),
-        resourceType: 'c',
+        resourceType: 'container',
         permissions: {
           read: true,
           add: false,
@@ -247,7 +249,7 @@ suite("Azure Blob", function() {
         refreshCount += 1;
         return blob.sas(containerName, null, {
           expiry:   new Date(Date.now() + 15 * 60 * 1000 + 100),
-          resourceType: 'c',
+          resourceType: 'container',
           permissions: {
             read: true,
             add: true,
@@ -280,7 +282,7 @@ suite("Azure Blob", function() {
         refreshCount += 1;
         return blob.sas(containerName, null, {
           expiry: new Date(Date.now() + 20 * 60 * 1000),
-          resourceType: 'c',
+          resourceType: 'container',
           permissions: {
             read: true,
             add: true,

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -226,4 +226,39 @@ suite("Utils", function() {
     assert(utils.dateToISOWithoutMS(date) === '2015-07-23T20:53:51Z',
            "Expected '2015-07-23T20:53:51Z' but got something else");
   });
+
+  test("isValidGUID", function() {
+    var value = 'f11489dc-f5bb-4eee-a205-b6bbe3a09cc5';
+    assert(utils.isValidGUID(value));
+
+    var value = '   f11\f489dc-f5  bb- 4eee-a2 05-b6bbe3a\n09cc5\r';
+    assert(utils.isValidGUID(value));
+
+    var value = 'f114-f5-4ee-a-000b6bbe3a0';
+    assert(utils.isValidGUID(value));
+
+    var value = '{f11489dc-f5bb-4eee-a205-b6bbe3a09cc5}';
+    assert(utils.isValidGUID(value));
+
+    var value = 'f11489dc-f5bb-4eee-a205-b6bbe3a09cc5}';
+    assert(utils.isValidGUID(value) === false);
+
+    var value = '{f114-f5-4ee-a-000b6bbe3a0}';
+    assert(utils.isValidGUID(value));
+
+    var value = '(f11489dc-f5bb-4eee-a205-b6bbe3a09cc5)';
+    assert(utils.isValidGUID(value));
+
+    var value = '(f11489dc-f5bb-4eee-a205-b6bbe3a09cc5';
+    assert(utils.isValidGUID(value) ===  false);
+
+    var value = '(f114-f5-4ee-a-000b6bbe3a0)';
+    assert(utils.isValidGUID(value));
+
+    var value = '{0xf11489dc,0xf5bb,0x4eee,{0xa2,0x05,0xb6,0xbb,0xe3,0xa0,0x9c,0xc5}}';
+    assert(utils.isValidGUID(value));
+
+    var value = '{0xf11489dc,f5bb,0x4eee,{0xa2,0x05,0xb6,0xbb,0xe3,0xa0,0x9c,0xc5}}';
+    assert(utils.isValidGUID(value) === false);
+  });
 });


### PR DESCRIPTION
- updates the service Azure storage service version: from 2015-12-11 to 2016-05-31 
- implementation for: getContainerProperties, getContainerACL, setContainerACL, leaseContainer, listBlobs
- changes for: setContainerMetadata, getContainerMetadata, deleteContainer in order to support leaseId
- authorization with SAS
- unit test changes: the name used for the creation of a container starts with a prefix and based on this prefix, all the containers are deleted at the end of the suite
- generalizes the authorizeWithSharedKey method (part 1 - tested only for blob storage)
- renames the queueParseError into parseError
- generalizes the authorizeWithSAS method (part 1 - tested only for blob storage)