### PR TITLE
Add err.module to trace unhandled errors

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,6 +82,9 @@ var retry = function retry(f, options) {
     return new Promise(function(accept) {
       accept(f(retry));
     }).catch(function(err) {
+      // Add 'fast-azure-storage' as module, so that errors can be traced
+      err.module = 'fast-azure-storage';
+
       // Add number of retries to the error object
       err.retries = retry;
 


### PR DESCRIPTION
This is a desperate attempt to exclude azure as the source for:
https://sentry.prod.mozaws.net/operations/taskcluster-queue/issues/3503120/