### PR TITLE
Bug 1481178: Fix retry to actually wait between retries

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,6 +77,14 @@ exports.TRANSIENT_HTTP_ERROR_CODES = TRANSIENT_HTTP_ERROR_CODES;
  * @returns {Promise} A promise that an iteration `f` of succeeded.
  */
 var retry = function retry(f, options) {
+  // apply defaults
+  options = Object.assign({}, {
+    retries: 5, 
+    delayFactor: 100,
+    randomizationFactor: 0.25,
+    maxDelay: 30000,
+    transientErrorCodes: TRANSIENT_HTTP_ERROR_CODES, 
+  }, options);
   var retry = 0;
   function attempt() {
     return new Promise(function(accept) {


### PR DESCRIPTION
When all options rae not passed, this function calls sleep(NaN) which is
not a sleep at all.  In particular, azure-entities fails to pass
randomizationFactor, which causes this.