### PR TITLE
Log retries

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -369,12 +369,19 @@ Table.prototype.request = function request(method, path, query, headers, json) {
   var self = this;
   return this.authorize(method, path, query, headers).then(function(options) {
     // Retry with retry policy
+    const start = process.hrtime();
     return utils.retry(function(retry) {
       debug("Request: %s %s, retry: %s", method, path, retry);
 
       // Construct a promise chain first handling the request, and then parsing
       // any potential error message
       return utils.request(options, data, self.timeout).then(function(res) {
+        let d = process.hrtime(start);
+        d = d[0] * 1000 + d[1] / 1000000; // Transform into milliseconds
+        if (d > 2000) {
+          console.log(`BUG-1481178-FAS-LONG-REQ: ${method} on ${path} with ${JSON.stringify(query)} took ${d} milliseconds.`);
+        }
+
         // Accept the response if it's 2xx, otherwise we construct and
         // throw an error
         if (200 <= res.statusCode && res.statusCode < 300) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -113,6 +113,8 @@ var retry = function retry(f, options) {
       delay = delay * (Math.random() * 2 * rf + 1 - rf);
       delay = Math.min(delay, options.maxDelay);
 
+      console.log('BUG-1481178-FAS-RETRY: ' + retry + ' DELAY: ' + delay + ' err: ' + err.code);
+
       // Sleep for the delay and try again
       return sleep(delay).then(function() {
         return attempt();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,6 +77,14 @@ exports.TRANSIENT_HTTP_ERROR_CODES = TRANSIENT_HTTP_ERROR_CODES;
  * @returns {Promise} A promise that an iteration `f` of succeeded.
  */
 var retry = function retry(f, options) {
+  // apply defaults
+  options = Object.assign({}, {
+    retries: 5, 
+    delayFactor: 100,
+    randomizationFactor: 0.25,
+    maxDelay: 30000,
+    transientErrorCodes: TRANSIENT_HTTP_ERROR_CODES, 
+  }, options);
   var retry = 0;
   function attempt() {
     return new Promise(function(accept) {


### PR DESCRIPTION
When we have a retry, let's see how long we're waiting and what the error message we're getting is.  This is a first pass to see if it's worthwhile adding deeper logging to look at the specific requests which are experiencing the problem.