### PR TITLE
Bug 1499701 - don't cache failed SAS credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ addons:
 env:
   global:
   - CXX=g++-4.8
-  - secure: OCRGkJ4DhmwEboxmy5GYXp9W0EV3MjuCWkV9HUsHMH06kIhG56TpKK1ebecprBW3MUlZO/UNdRCyKz8hNzGGeYDpdUg4UbBQT6jL365wE0p5u+6AZ111Dcu0NEJt0mchSEC54N8aaI4lv2w1FRuhggwfVqYE849vTIY1cRJDaHE=
-  - secure: B3DSMqcK4FDj5nPlWFtXoYIazPXsZlrHR23aY1XaFqWtjJPZ/4gLBgxI1rx2PXXwYbbgYN93wpkVxeFJ2sF9wqpzXCFEZ9ewKhjF0h7zze/LPhIaW5RfrFlfMIvSeHJB5L1bsL2lHbpAHUSBoyN8GDkjnjAqKXISjXqy6EaRUKw=
 notifications:
   irc:
     channels:

--- a/lib/authorization.js
+++ b/lib/authorization.js
@@ -10,7 +10,7 @@ var utils             = require('./utils');
 var authorizeWithRefreshSAS = function authorizeWithRefreshSAS(method, path, query, headers) {
   var self = this;
   // Check if we should refresh SAS
-  if (Date.now() > this._nextSASRefresh && this._nextSASRefresh !== 0) {
+  if (!this._sas || (Date.now() > this._nextSASRefresh && this._nextSASRefresh !== 0)) {
     debug("Refreshing shared-access-signature");
     // Avoid refreshing more than once
     this._nextSASRefresh = 0;
@@ -33,6 +33,11 @@ var authorizeWithRefreshSAS = function authorizeWithRefreshSAS(method, path, que
         }
 
         return sasString;
+      }).catch(err => {
+        debug("shared-access-signature refresh failed:", err);
+        // sas failed, so don't cache it, but throw the error for this request
+        this._sas = null;
+        throw err;
       });
   }
 


### PR DESCRIPTION
This will help services recover much more quickly from a failure of
whatever is providing SAS credentials.