### PR TITLE
Bug 1604649 - actually provide a default for randomizationFactor

### DIFF
--- a/lib/blob.js
+++ b/lib/blob.js
@@ -156,6 +156,7 @@ function Blob(options) {
     agent:                agent.globalAgent,
     retries:              5,
     delayFactor:          100,
+    randomizationFactor:  0.25,
     maxDelay:             30 * 1000,
     transientErrorCodes:  TRANSIENT_ERROR_CODES,
     accountId:            undefined,

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -117,6 +117,7 @@ function Queue(options) {
     agent:                agent.globalAgent,
     retries:              5,
     delayFactor:          100,
+    randomizationFactor:  0.25,
     maxDelay:             30 * 1000,
     transientErrorCodes:  TRANSIENT_ERROR_CODES,
     accountId:            undefined,

--- a/lib/table.js
+++ b/lib/table.js
@@ -148,6 +148,7 @@ function Table(options) {
     agent:                agent.globalAgent,
     retries:              5,
     delayFactor:          100,
+    randomizationFactor:  0.25,
     maxDelay:             30 * 1000,
     transientErrorCodes:  TRANSIENT_ERROR_CODES,
     accountId:            undefined,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -101,7 +101,9 @@ var retry = function retry(f, options) {
       // Compute delay
       var delay = Math.pow(2, retry) * options.delayFactor;
       var rf = options.randomizationFactor;
-      delay = delay * (Math.random() * 2 * rf + 1 - rf);
+      if (rf) {
+        delay = delay * (Math.random() * 2 * rf + 1 - rf);
+      }
       delay = Math.min(delay, options.maxDelay);
 
       // Sleep for the delay and try again


### PR DESCRIPTION
Without this, the delay calculation comes out to NaN, which means 0, so
errors are retried immediately -- not a great idea in rate-limiting
cases!